### PR TITLE
docs: pair <script type="module"> with <script nomodule> fallback

### DIFF
--- a/src/content/docs/en/basics/client-side-rendering.mdx
+++ b/src/content/docs/en/basics/client-side-rendering.mdx
@@ -10,7 +10,10 @@ are both fine.
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
+
+The `nomodule` fallback ensures the widget also loads in environments that do not execute ES module scripts (older browsers, some crawlers).
 
 Now, you can either render the Procaptcha widget implicitly or explicitly.
 
@@ -42,6 +45,7 @@ is solved.
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -72,6 +76,12 @@ id `procaptcha-container` where the widget will be rendered.
             type="module"
             id="procaptcha-script"
             src="https://js.prosopo.io/js/procaptcha.bundle.js"
+            async
+            defer
+        ></script>
+        <script
+            nomodule
+            src="https://js.prosopo.io/js/procaptcha.bundle.iife.js"
             async
             defer
         ></script>

--- a/src/content/docs/en/basics/index.mdx
+++ b/src/content/docs/en/basics/index.mdx
@@ -44,7 +44,8 @@ To add the Procaptcha widget:
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/en/basics/invisible-captcha.mdx
+++ b/src/content/docs/en/basics/invisible-captcha.mdx
@@ -76,7 +76,8 @@ Add the `procaptcha` class and data attributes directly to your form elements:
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -116,7 +117,8 @@ For more control over the CAPTCHA lifecycle:
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/en/demos/client-example-bundle.mdx
+++ b/src/content/docs/en/demos/client-example-bundle.mdx
@@ -21,6 +21,7 @@ the [Prosopo portal](https://portal.prosopo.io).
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">


### PR DESCRIPTION
## Summary

Updates the recommended Procaptcha script-include snippet in the 4 EN doc files that show it. Customers now ship both a `<script type="module">` (modern browsers, Googlebot) and a `<script nomodule>` (Ahrefs, older crawlers, legacy browsers) pointing at the new IIFE artifact.

## Why

Ahrefs (and other crawlers without ES-module support) currently skip the Procaptcha bundle entirely, so customer integrations contribute zero backlinks. Google Search Console shows 100+ customer domains linking to prosopo.io (printplanet.de: 1 page, twickets.live, pimeyes.com, plus many DR 60+ sites). Ahrefs shows zero of them despite us verifying the link is in the rendered DOM when JS runs.

FriendlyCaptcha already does this — their integration snippet pairs `type="module"` with `nomodule`, which is consistent with their broad Ahrefs backlink coverage on the same client-side-rendered widget pattern.

## What

- `src/content/docs/en/basics/index.mdx` — main install snippet
- `src/content/docs/en/basics/client-side-rendering.mdx` — three snippets (head include, implicit-render example, explicit-render example)
- `src/content/docs/en/basics/invisible-captcha.mdx` — two snippets (implicit, explicit)
- `src/content/docs/en/demos/client-example-bundle.mdx` — bundled-example head include

Also fixes a side issue: 3 of these snippets had `<script src="..." async defer>` without `type="module"`. Those were broken against the ES-module bundle customers actually receive (the bundle output starts with `import { a, e, r, b } from "./index-…js"`, which fails to parse as a classic script). Customers who follow the docs literally would get a parse error; the new snippet works correctly in all environments.

## Depends on

The IIFE bundle artifact (`procaptcha.bundle.iife.js`) needs to exist on the CDN. The build change is in: prosopo/captcha#2574

After that PR lands and the artifact is deployed, this doc PR is safe to merge.

## TODO (not in this PR)

- Translated docs (de, it, pt-br, ja, etc.) — 20 files; sync via lunaria after this lands.

## Test plan

- [ ] Render docs locally and verify code blocks are formatted correctly
- [ ] Confirm IIFE artifact is on CDN before merging (depends on prosopo/captcha#2574 + ops deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)