### PR TITLE
docs: add <script nomodule> iife fallback to recommended snippets

### DIFF
--- a/src/content/docs/de/basics/client-side-rendering.mdx
+++ b/src/content/docs/de/basics/client-side-rendering.mdx
@@ -10,6 +10,7 @@ sind beide in Ordnung.
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 
 Nun können Sie das Procaptcha Widget entweder implizit oder explizit rendern.
@@ -42,6 +43,7 @@ gelöst wurde.
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -75,6 +77,7 @@ ID `procaptcha-container` erstellt, in dem das Widget gerendert wird.
             async
             defer
         ></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/src/content/docs/de/basics/index.mdx
+++ b/src/content/docs/de/basics/index.mdx
@@ -44,7 +44,8 @@ So fügen Sie das Procaptcha Widget hinzu:
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/de/basics/invisible-captcha.mdx
+++ b/src/content/docs/de/basics/invisible-captcha.mdx
@@ -76,7 +76,8 @@ Fügen Sie die `procaptcha`-Klasse und Datenattribute direkt zu Ihren Formularel
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -116,7 +117,8 @@ Für mehr Kontrolle über den CAPTCHA-Lebenszyklus:
 <!DOCTYPE html>
 <html>
 <head>    
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/de/demos/client-example-bundle.mdx
+++ b/src/content/docs/de/demos/client-example-bundle.mdx
@@ -21,6 +21,7 @@ den `<YOUR SITE KEY HERE>`-Platzhalter durch Ihren eigenen sitekey zu ersetzen. 
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">

--- a/src/content/docs/en/basics/client-side-rendering.mdx
+++ b/src/content/docs/en/basics/client-side-rendering.mdx
@@ -10,6 +10,7 @@ are both fine.
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 
 Now, you can either render the Procaptcha widget implicitly or explicitly.
@@ -42,6 +43,7 @@ is solved.
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -75,6 +77,7 @@ id `procaptcha-container` where the widget will be rendered.
             async
             defer
         ></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/src/content/docs/en/basics/index.mdx
+++ b/src/content/docs/en/basics/index.mdx
@@ -44,7 +44,8 @@ To add the Procaptcha widget:
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/en/basics/invisible-captcha.mdx
+++ b/src/content/docs/en/basics/invisible-captcha.mdx
@@ -76,7 +76,8 @@ Add the `procaptcha` class and data attributes directly to your form elements:
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -116,7 +117,8 @@ For more control over the CAPTCHA lifecycle:
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/en/demos/client-example-bundle.mdx
+++ b/src/content/docs/en/demos/client-example-bundle.mdx
@@ -21,6 +21,7 @@ the [Prosopo portal](https://portal.prosopo.io).
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">

--- a/src/content/docs/es/basics/client-side-rendering.mdx
+++ b/src/content/docs/es/basics/client-side-rendering.mdx
@@ -8,6 +8,7 @@ Primero, debe incluir el recurso JavaScript de Procaptcha en algún lugar de su 
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 
 Ahora, puede renderizar el widget de Procaptcha de forma implícita o explícita.
@@ -33,6 +34,7 @@ Aquí hay un ejemplo completo donde Procaptcha se está utilizando para proteger
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -64,6 +66,7 @@ El script se carga en el encabezado del documento y se le da el id `procaptcha-s
             async
             defer
         ></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/src/content/docs/es/basics/index.mdx
+++ b/src/content/docs/es/basics/index.mdx
@@ -44,7 +44,8 @@ Para agregar el widget de Procaptcha:
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/es/basics/invisible-captcha.mdx
+++ b/src/content/docs/es/basics/invisible-captcha.mdx
@@ -79,7 +79,8 @@ Agregue la clase `procaptcha` y los atributos de datos directamente a sus elemen
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -119,7 +120,8 @@ Para más control sobre el ciclo de vida del CAPTCHA:
 <!DOCTYPE html>
 <html>
 <head>    
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/es/demos/client-example-bundle.mdx
+++ b/src/content/docs/es/demos/client-example-bundle.mdx
@@ -21,6 +21,7 @@ el [portal de Prosopo](https://portal.prosopo.io).
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">

--- a/src/content/docs/fr/basics/client-side-rendering.mdx
+++ b/src/content/docs/fr/basics/client-side-rendering.mdx
@@ -8,6 +8,7 @@ Tout d'abord, vous devez inclure la ressource JavaScript Procaptcha quelque part
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 
 Maintenant, vous pouvez soit rendre le widget Procaptcha implicitement, soit explicitement.
@@ -33,6 +34,7 @@ Voici un exemple complet où Procaptcha est utilisé pour protéger un formulair
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -64,6 +66,7 @@ Le script est chargé dans le head du document et se voit attribuer l'id `procap
             async
             defer
         ></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/src/content/docs/fr/basics/index.mdx
+++ b/src/content/docs/fr/basics/index.mdx
@@ -44,7 +44,8 @@ Pour ajouter le widget Procaptcha :
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/fr/basics/invisible-captcha.mdx
+++ b/src/content/docs/fr/basics/invisible-captcha.mdx
@@ -76,7 +76,8 @@ Ajoutez la classe `procaptcha` et les attributs de données directement à vos �
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -116,7 +117,8 @@ Pour plus de contrôle sur le cycle de vie du CAPTCHA :
 <!DOCTYPE html>
 <html>
 <head>    
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/fr/demos/client-example-bundle.mdx
+++ b/src/content/docs/fr/demos/client-example-bundle.mdx
@@ -19,6 +19,7 @@ Enregistrez ce fichier sur votre machine locale et ouvrez-le dans un navigateur 
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">

--- a/src/content/docs/it/basics/client-side-rendering.mdx
+++ b/src/content/docs/it/basics/client-side-rendering.mdx
@@ -8,6 +8,7 @@ Prima di tutto, deve includere la risorsa JavaScript Procaptcha da qualche parte
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 
 Ora, può renderizzare il widget Procaptcha implicitamente o esplicitamente.
@@ -33,6 +34,7 @@ Ecco un esempio completo dove Procaptcha viene utilizzato per proteggere un form
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -64,6 +66,7 @@ Lo script viene caricato nell'head del documento e gli viene assegnato l'id `pro
             async
             defer
         ></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/src/content/docs/it/basics/index.mdx
+++ b/src/content/docs/it/basics/index.mdx
@@ -44,7 +44,8 @@ Per aggiungere il widget Procaptcha:
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/it/basics/invisible-captcha.mdx
+++ b/src/content/docs/it/basics/invisible-captcha.mdx
@@ -76,7 +76,8 @@ Aggiunga la classe `procaptcha` e gli attributi data direttamente agli elementi 
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -116,7 +117,8 @@ Per un maggiore controllo sul ciclo di vita del CAPTCHA:
 <!DOCTYPE html>
 <html>
 <head>    
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/it/demos/client-example-bundle.mdx
+++ b/src/content/docs/it/demos/client-example-bundle.mdx
@@ -19,6 +19,7 @@ Salvi questo file sulla sua macchina locale e lo apra in un browser per vedere i
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">

--- a/src/content/docs/pt-br/basics/client-side-rendering.mdx
+++ b/src/content/docs/pt-br/basics/client-side-rendering.mdx
@@ -10,6 +10,7 @@ são ambas opções válidas.
 
 ```html
 <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 
 Agora, você pode renderizar o widget Procaptcha implicitamente ou explicitamente.
@@ -40,6 +41,7 @@ for resolvido.
     <head>
         <title>Procaptcha Demo</title>
         <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <form action="" method="POST">
@@ -73,6 +75,7 @@ id `procaptcha-container` onde o widget será renderizado.
             async
             defer
         ></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div id="procaptcha-container"></div>

--- a/src/content/docs/pt-br/basics/index.mdx
+++ b/src/content/docs/pt-br/basics/index.mdx
@@ -44,7 +44,8 @@ Para adicionar o widget Procaptcha:
 <div>
 
 ```html
-<script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+<script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 ```
 </div>
 

--- a/src/content/docs/pt-br/basics/invisible-captcha.mdx
+++ b/src/content/docs/pt-br/basics/invisible-captcha.mdx
@@ -76,7 +76,8 @@ Adicione a classe `procaptcha` e atributos de dados diretamente aos seus element
 <!DOCTYPE html>
 <html>
 <head>
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form>
@@ -116,7 +117,8 @@ Para mais controle sobre o ciclo de vida do CAPTCHA:
 <!DOCTYPE html>
 <html>
 <head>    
-    <script src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+    <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
 </head>
 <body>
     <form id="demo-form">

--- a/src/content/docs/pt-br/demos/client-example-bundle.mdx
+++ b/src/content/docs/pt-br/demos/client-example-bundle.mdx
@@ -19,6 +19,7 @@ Salve este arquivo em sua máquina local e abra-o em um navegador para ver o bun
         <link href="//cdn.muicss.com/mui-0.10.3/css/mui.min.css" rel="stylesheet" type="text/css" />
         <title>Procaptcha demo: Simple page</title>
         <script id="procaptchaScript" type="module" src="https://js.prosopo.io/js/procaptcha.bundle.js" async defer></script>
+        <script nomodule src="https://js.prosopo.io/js/procaptcha.bundle.iife.js" async defer></script>
     </head>
     <body>
         <div class="mui-container">


### PR DESCRIPTION
## Summary
- Add `<script nomodule src=".../procaptcha.bundle.iife.js" async defer>` as a sibling fallback to every `<script type="module">` Procaptcha snippet across all 6 language docs (en, de, fr, es, it, pt-br) and 4 affected pages (`basics/index`, `basics/invisible-captcha`, `basics/client-side-rendering`, `demos/client-example-bundle`).
- Mirrors the friendly-challenge pattern. Crawlers and runtimes that don't execute `type="module"` (notably Ahrefs') will fall back to the iife and still mount the widget / expose the outbound prosopo.io link in the rendered DOM.
- Where the snippet was previously a bare `<script src=...>` (`basics/index`, `basics/invisible-captcha`), upgraded to `<script type="module" src=...>` so the nomodule fallback semantics actually apply.

## Pairs with
- prosopo/captcha#2574 — iife artifact + procaptcha-bundle build wiring
- prosopo/captcha-private#3366 — deploy-side iife upload
- prosopo/captcha-private#3388 — `publish_release.yml` iife build (so the iife lands in future release zips by default)

## Test plan
- [ ] Visual scan of each `basics/*` and `demos/*` page in en + one other locale to confirm rendering
- [ ] Confirm `https://js.prosopo.io/js/procaptcha.bundle.iife.js` resolves on prod CDN once #3388 has shipped a release

🤖 Generated with [Claude Code](https://claude.com/claude-code)