### PR TITLE
ci: add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -29,6 +29,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
     GITHUB_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
     GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -11,6 +11,10 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+  actions: write
+
 env:
     GITHUB_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
     GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}

--- a/.github/workflows/event_push.yml
+++ b/.github/workflows/event_push.yml
@@ -11,6 +11,9 @@ concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
     GITHUB_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
     GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
     GITHUB_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
     GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
     GITHUB_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
     GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}

--- a/.github/workflows/update_staging.yml
+++ b/.github/workflows/update_staging.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
     GITHUB_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}
     GH_TOKEN: ${{ secrets.PROSOPONATOR_PAT }}


### PR DESCRIPTION
## Summary
All GitHub Actions workflows in this repo previously had **no `permissions:` block**, so each inherited the repository default `GITHUB_TOKEN` scope (potentially read/write-all).

This adds explicit least-privilege top-level permissions to all 6 workflows.

## Details
Write operations (releases, PR creation, `git push`) in these workflows authenticate via `PROSOPONATOR_PAT`, not the built-in `GITHUB_TOKEN`. So the default token only needs:
- `contents: read` — all workflows (for checkout)
- `actions: write` — `cache.yml` additionally, for cache save/cleanup

No write scope is required on the built-in token because the PAT carries auth for all push/release/PR steps.