### PR TITLE
chore(ci): add --no-audit --no-fund --prefer-offline to npm install commands

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -53,7 +53,8 @@ jobs:
                   node-version-file: 'package.json'
             - run: npm i -g "npm@$(jq -r .engines.npm < package.json)"
 
-            - run: npm ci
+            - run: npm ci --no-audit --no-fund --prefer-offline
+
 
             # install cypress so we don't have to do that every time
             - run: npx cypress install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,8 @@ jobs:
                   node-version-file: 'package.json'
             - run: npm i -g "npm@$(jq -r .engines.npm < package.json)"
 
-            - run: npm ci
+            - run: npm ci --no-audit --no-fund --prefer-offline
+
 
             # check everything builds
             - run: npm run build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,8 @@ jobs:
           node-version-file: 'package.json'
       - run: npm i -g "npm@$(jq -r .engines.npm < package.json)"
 
-      - run: npm ci
+      - run: npm ci --no-audit --no-fund --prefer-offline
+
 
       - run: npm run lint
 


### PR DESCRIPTION
Adds `--no-audit --no-fund --prefer-offline` to all `npm ci`/`npm install` commands in GitHub workflows to speed up CI installs.