### PR TITLE
fix(a11y/seo): downgrade FeedbackButton dialog titles from h1 to h2

### DIFF
--- a/src/components/tutorial/FeedbackButton.astro
+++ b/src/components/tutorial/FeedbackButton.astro
@@ -36,7 +36,7 @@ const instanceId = Math.round(Math.random() * 10e9).toString(36);
 				<Icon name="close" size="2em" />
 			</button>
 			<div class="select-pane" tabindex="-1">
-				<h1><UIString key="feedback.formTitle" /></h1>
+				<h2 class="dialog-title"><UIString key="feedback.formTitle" /></h2>
 				<div class="select-buttons">
 					<a
 						class="github-button"
@@ -68,7 +68,7 @@ const instanceId = Math.round(Math.random() * 10e9).toString(36);
 					<span class="sr-only"><UIString key="feedback.close" /></span>
 					<Icon name="left-arrow" size="1em" />
 				</button>
-				<h1><UIString key="feedback.sendFeedback" /></h1>
+				<h2 class="dialog-title"><UIString key="feedback.sendFeedback" /></h2>
 				<fieldset class="category-options">
 					<legend class="sr-only"><UIString key={'feedback.categoryGroupLabel'} /></legend>
 					{
@@ -283,7 +283,7 @@ const instanceId = Math.round(Math.random() * 10e9).toString(36);
 		display: contents;
 	}
 
-	h1 {
+	.dialog-title {
 		padding: 0 calc(var(--feedback-form-close-icon-size) + var(--feedback-form-padding));
 		font-size: var(--sl-text-xl);
 		font-weight: bold;


### PR DESCRIPTION
## Summary
- The feedback modal is hidden by default but still lives in the DOM on every docs page, so crawlers were seeing two extra `<h1>` elements (`feedback.formTitle` and `feedback.sendFeedback`) alongside the real page `<h1>`.
- This tripped duplicate-H1 audit warnings on **every** localised copy of the docs (\~250+ URLs across en/es/pt-br/fr/de/it).
- Both dialog titles are now `<h2 class="dialog-title">`; the scoped `h1 { … }` selector is renamed to `.dialog-title { … }` so the styling is preserved without depending on the tag name.
- Nested `.select-buttons h2` rules are unaffected.

## Test plan
- [ ] Open a docs page, click the feedback button in the sidebar, and confirm the dialog still renders with the same title styling.
- [ ] Confirm the two internal panes (select pane and form pane) both show their heading correctly.
- [ ] View source on any docs URL and confirm exactly one `<h1>` remains (the Starlight page title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)