### PR TITLE
fix(ci): repair the indentation that made every workflow unparseable

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -48,7 +48,7 @@ jobs:
         steps:
             - name: Print contexts
               uses: prosopo/captcha/.github/actions/print_contexts@main
-                with:
+              with:
                 INPUTS_CONTEXT: ${{ toJson(inputs) }}
                 NEEDS_CONTEXT: ${{ toJson(needs) }}
                 VARS_CONTEXT: ${{ toJson(vars) }}

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - name: Print contexts
               uses: prosopo/captcha/.github/actions/print_contexts@main
-                with:
+              with:
                 INPUTS_CONTEXT: ${{ toJson(inputs) }}
                 NEEDS_CONTEXT: ${{ toJson(needs) }}
                 VARS_CONTEXT: ${{ toJson(vars) }}

--- a/.github/workflows/event_push.yml
+++ b/.github/workflows/event_push.yml
@@ -30,7 +30,7 @@ jobs:
         steps:
             - name: Print contexts
               uses: prosopo/captcha/.github/actions/print_contexts@main
-                with:
+              with:
                 INPUTS_CONTEXT: ${{ toJson(inputs) }}
                 NEEDS_CONTEXT: ${{ toJson(needs) }}
                 VARS_CONTEXT: ${{ toJson(vars) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         steps:
             - name: Print contexts
               uses: prosopo/captcha/.github/actions/print_contexts@main
-                with:
+              with:
                 INPUTS_CONTEXT: ${{ toJson(inputs) }}
                 NEEDS_CONTEXT: ${{ toJson(needs) }}
                 VARS_CONTEXT: ${{ toJson(vars) }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Print contexts
         uses: prosopo/captcha/.github/actions/print_contexts@main
-          with:
+        with:
           INPUTS_CONTEXT: ${{ toJson(inputs) }}
           NEEDS_CONTEXT: ${{ toJson(needs) }}
           VARS_CONTEXT: ${{ toJson(vars) }}

--- a/.github/workflows/update_staging.yml
+++ b/.github/workflows/update_staging.yml
@@ -26,7 +26,7 @@ jobs:
         steps:
             - name: Print contexts
               uses: prosopo/captcha/.github/actions/print_contexts@main
-                with:
+              with:
                 INPUTS_CONTEXT: ${{ toJson(inputs) }}
                 NEEDS_CONTEXT: ${{ toJson(needs) }}
                 VARS_CONTEXT: ${{ toJson(vars) }}


### PR DESCRIPTION
**No CI has run in this repo since at least 2026-08-04.** Every workflow run since then failed immediately, and `gh run list` shows the runs named by filename rather than by workflow name — the signature of a file GitHub could not parse:

```
.github/workflows/update_staging.yml  failure  2026-08-04T15:14:56Z
.github/workflows/cache.yml           failure  2026-08-04T15:14:55Z
.github/workflows/tests.yml           failure  2026-08-04T15:14:55Z
...
```

The cause is the same in all six files: the `with:` of the `print_contexts` step is indented one level deeper than its `uses:`, which makes it a mapping value inside a scalar and is a YAML error, not merely bad style:

```
- name: Print contexts
  uses: prosopo/captcha/.github/actions/print_contexts@main
    with:            # <-- one level too deep
    INPUTS_CONTEXT: ...
```

This realigns `with:` with `uses:` and puts its keys one level below. Each file now parses. No other change — the inputs and their values are untouched.

Worth checking after merge that the workflows actually pass, since none of them has run for over a week and other breakage may have accumulated behind this.