### PR TITLE
ci: cancel in-flight runs when a PR is converted to draft

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
       - synchronize # when a PR is pushed to
       - reopened # when a PR is reopened
       - ready_for_review # when a PR is marked as ready for review (e.g. taken off draft mode)
+      - converted_to_draft # so the concurrency group cancels the in-flight run
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Same change as https://github.com/prosopo/captcha-private/pull/4113, https://github.com/prosopo/captcha/pull/3033 and https://github.com/prosopo/Protect/pull/427.

One line: `tests.yml` is the only `pull_request`-triggered workflow here, and it already has a `concurrency` group with `cancel-in-progress: true` plus a `draft == false` job gate. So adding the trigger type is the whole change — the group does the cancelling, and the existing gate makes the new run skip (on a `converted_to_draft` event the PR is draft by definition).

**Stacked on https://github.com/prosopo/docs/pull/53**, which repairs the YAML that currently makes every workflow in this repo unparseable. Merge that first; this targets its branch, so retarget to `main` once it lands. Without it there is nothing here for GitHub to read.