### PR TITLE
docs(protect-edge): retrospective rewrite from trainoclock onboarding

### DIFF
--- a/src/content/docs/en/protect-edge/cloudflare-worker.mdx
+++ b/src/content/docs/en/protect-edge/cloudflare-worker.mdx
@@ -6,41 +6,117 @@ i18nReady: true
 
 The Prosopo Protect Cloudflare Worker sits in front of your origin and runs Protect's decision on every request. On `allow` it forwards to your origin; on `block` / `challenge` it returns immediately with a branded interstitial (or JSON error for API calls), no origin fetch.
 
+## Two-part install — read this first
+
+A production Prosopo Protect integration is **two independent pieces working together**. Deploying only one leaves your site unprotected. Both are covered by this guide.
+
+1. **The Cloudflare Worker (server-side).** Sits in front of your origin. Runs the verdict on every request. Blocks bad traffic before it reaches your server. This is `worker.js` + `wrangler.toml`.
+
+2. **The Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the worker returns a challenge. This is a single `<script>` tag in your HTML.
+
+Without the worker, no request is scored. Without the bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the worker path only — a green worker with no bundle deployed **looks working** but every real user still fails on their first XHR.
+
+Deploy them in either order, but ship both before rollout.
+
 ## What you get
 
-A single JavaScript file, `worker.js`, delivered per site and per environment. It's self-contained — no dependencies, ~50 KB.
+- `worker.js` — the worker code, delivered per site and per environment. Self-contained, ~50 KB. Same file for every customer; per-site config lives in `wrangler.toml`.
+- `wrangler.toml` — deployment config, pre-set with your `PROTECT_URL`.
+- `README.md` — customer-specific quick reference mirroring this guide.
 
 ## Prerequisites
 
-- A Cloudflare account with **Workers Scripts: Read + Edit** on the API token you'll use.
+- A Cloudflare account with an API token carrying:
+  - **Account → Workers Scripts → Edit** (upload the worker code).
+  - **Zone → Workers Routes → Edit** on the zone you'll bind the worker to (only needed when you move from `workers.dev` to a production route).
 - [`wrangler`](https://developers.cloudflare.com/workers/wrangler/install-and-update/) installed locally (`npm i -g wrangler`).
-- A Cloudflare zone (for a custom domain) or a workers.dev subdomain (fine for testing).
-- A CNAME record for your Protect API hostname — see the next section.
+- A Cloudflare zone for your production domain (a `workers.dev` subdomain is fine for the initial test).
+- Your Prosopo account manager has:
+  - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding — see [Portal settings checklist](#portal-settings-checklist) below.
+  - Issued you a `CLIENT_JWT` (long-lived token authenticating the worker to the Protect API).
 
-## DNS: point your Protect subdomain at Prosopo
+## DNS: `protect.<your-domain>` as **DNS-only** (grey cloud)
 
-The worker talks to your Protect API over HTTPS at a hostname you own — typically `protect.<your-domain>`. Create a CNAME record on your DNS pointing that hostname at Prosopo:
+The worker talks to Protect at a hostname you own — typically `protect.<your-domain>`. Create a CNAME record on that hostname pointing at Prosopo:
 
 ```
 protect.<your-domain>   CNAME   protect.prosopo.io
 ```
 
-Then enter the same hostname (e.g. `protect.example.com`) in the **CNAME** field of your site's Protect settings on your [Prosopo dashboard](https://portal.prosopo.io/). Prosopo uses this to route TLS requests arriving at that SNI to your site's configuration.
+**Set the proxy status to DNS only (grey cloud), not proxied (orange cloud).** This is not optional.
 
-Set `BUMBLEBEE_URL` in `wrangler.toml` (below) to `https://protect.<your-domain>` — the CNAMEd hostname, not `protect.prosopo.io` directly. TLS certificate handling is managed by Prosopo automatically for the CNAMEd hostname.
+Why: Prosopo Protect's risk engine derives most of its bot-signal value from the raw TLS handshake — cipher-suite order, extensions, timing between packets (JA4, JA4H, JA4L, JA4T fingerprints). If Cloudflare's proxy terminates the browser's TLS at its edge, what reaches Prosopo is a fresh TLS connection from Cloudflare's own stack, identical for every user. The JA4 signals collapse to a single value and the risk-scoring pipeline degrades to noise.
 
-Verify the DNS is live before deploying the worker:
+Grey-cloud on `protect.<your-domain>` **only** — every other DNS record on your zone (including your main `www` record fronted by this worker) stays exactly as it is. This one subdomain needs to point directly at our origin so the browser's TLS handshake reaches us intact.
 
-```bash
-dig protect.<your-domain>
-# should show a CNAME to protect.prosopo.io and an A record.
+### Coordinate cert issuance with your account manager
+
+Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain via Let's Encrypt on our infrastructure. This is a two-step handoff:
+
+1. **You**: create the CNAME record as DNS-only. Verify it's live:
+
+   ```bash
+   dig protect.<your-domain>
+   # ANSWER SECTION should show a CNAME to protect.prosopo.io
+   # and an A record resolving directly to our edge (not Cloudflare's).
+   ```
+
+   If the A record starts with `104.` or `172.` you're still orange-cloud — flip the record to grey-cloud before proceeding.
+
+2. **Us**: email your account manager once DNS is grey-clouded and propagated. We issue the certificate on our end (~30 seconds), then confirm back. Attempting to deploy the worker before we've issued the cert results in HTTP 526 (SSL Handshake Failed) on every access-check call, and the worker fails open — no request is actually scored.
+
+Once the cert is in place it auto-renews on our end every 60 days. You don't touch it again.
+
+## Step 1: Add the Protect JS bundle to every HTML page
+
+**This step is mandatory.** Without the bundle no session cookie is ever set, and the worker returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity.
+
+Add this snippet to every HTML page your site serves — a shared header or footer template is the usual spot:
+
+```html
+<script>
+  window.prosopo_config = {
+    site_key: "<your-site-key>",
+    protect_url: "https://protect.<your-domain>"
+  };
+</script>
+<script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
 ```
 
-**Do not use NS delegation.** Only a CNAME record is supported; NS would delegate the whole subdomain to Prosopo's nameservers, which isn't the model.
+Both tags are required. The first sets `window.prosopo_config` before the second loads — the bundle reads that config to know which Protect API to talk to. Skipping the first tag causes the bundle to fall back to the CDN's own origin (`js.protect.prosopo.io`) as its API URL, which returns 405 on the CORS preflight for `/api/protect/init` and hangs the bundle's patched `fetch`.
 
-## Deploy
+On first page load the bundle:
 
-Cloudflare Workers is configured by a small `wrangler.toml` alongside the bundle. Create one next to `worker.js`:
+1. Calls `POST https://protect.<your-domain>/api/protect/init`.
+2. Receives a `prosopo_session` cookie scoped to `.<your-domain>`.
+3. Loads a per-session telemetry runtime script that collects the bot-signal data used for risk scoring.
+
+Every subsequent request from that browser carries the cookie, and the worker looks up a real verdict on `/api/*` / `/forms/*` calls.
+
+### Gate fast form submissions and link clicks (optional)
+
+Users can click **Submit** before the bundle finishes creating the session. The browser fires a full-page POST with no cookie and gets a 401. Security is correct — UX is bad.
+
+Opt any form or link into automatic held-until-session-ready behaviour by adding the `data-prosopo-gate` attribute:
+
+```html
+<form action="/forms/search.php" method="post" data-prosopo-gate>
+  <!-- ... -->
+</form>
+
+<nav data-prosopo-gate>
+  <a href="/section-a/">Section A</a>
+  <a href="/section-b/">Section B</a>
+</nav>
+```
+
+The bundle intercepts marked forms / same-origin links in the capture phase, holds up to 8 seconds waiting for the session, then releases with the cookie in place. The submit button flips `disabled` + `aria-busy` while held so the user gets visual feedback. Ctrl/Cmd-click, middle-click, `target="_blank"`, `download` attributes, hash-only links, and cross-origin links are always passed through untouched.
+
+Attributes on an ancestor cover every descendant form/link, so `<nav data-prosopo-gate>` gates every link inside.
+
+## Step 2: Deploy the worker
+
+Cloudflare Workers is configured by a `wrangler.toml` alongside the worker code:
 
 ```toml
 name = "prosopo-protect"
@@ -48,64 +124,130 @@ main = "worker.js"
 compatibility_date = "2025-01-15"
 compatibility_flags = ["nodejs_compat"]
 
-# Optional: bind static assets you want the worker to serve when a
-# request is allowed. Delete this block if your worker fronts an
-# upstream origin instead.
-[assets]
-directory = "./public"
-binding = "ASSETS"
-run_worker_first = true
-
 [vars]
-BUMBLEBEE_URL = "https://protect.prosopo.io"
+PROTECT_URL = "https://protect.<your-domain>"
+# ORIGIN_URL is where the worker forwards allowed requests. Set this
+# for any deployment that fronts a real backend. Two hostnames are
+# required — the worker sits on <www>, forwards to a different name
+# (e.g. origin.<your-domain>, grey-clouded, pointing at your real
+# server) — pointing back at <www> would loop through this worker
+# forever.
+ORIGIN_URL = "https://origin.<your-domain>"
+
+# Static assets are optional. Uncomment when the worker itself serves
+# files instead of forwarding to an origin (rare in production — the
+# origin usually serves them). `run_worker_first` uses positive
+# patterns for paths the worker runs on and `!`-prefixed patterns
+# for paths served directly (Protect entirely bypassed).
+# [assets]
+# directory = "./public"
+# binding = "ASSETS"
+# run_worker_first = [
+#     "/*",
+#     "!/js/*",
+#     "!/css/*",
+#     "!/img/*",
+#     "!/favicon.ico",
+#     "!/manifest/*",
+#     "!/apple-touch-icon-*.png",
+#     "!/robots.txt",
+#     "!/sitemap.xml",
+# ]
+
+[observability]
+enabled = true
 ```
 
-Then deploy:
+Push `CLIENT_JWT` as a secret (persists across deploys) and deploy:
 
 ```bash
-export CLOUDFLARE_API_TOKEN=<token-with-Workers-Scripts-Read+Edit>
+export CLOUDFLARE_API_TOKEN=<your-token>
 
-# 1. Push the authentication token as a wrangler secret (once per environment)
+# One-off: authenticate the worker to the Protect API.
 echo "<your-CLIENT_JWT>" | wrangler secret put CLIENT_JWT
 
-# 2. Deploy
 wrangler deploy
 ```
 
-The worker is now live at `https://<name>.<your-subdomain>.workers.dev`. To attach to a custom hostname, add a **Route** in `wrangler.toml` (e.g. `route = "example.com/*"`) and redeploy.
+The worker is now live at `https://<name>.<your-subdomain>.workers.dev`. Once the verify commands below all pass, attach it to your production hostname by uncommenting the `routes` block in `wrangler.toml`:
 
-Your account manager will let you know when a new bundle is available. Replace `worker.js` and re-run `wrangler deploy`. The secret persists across deploys.
+```toml
+routes = [
+    { pattern = "www.<your-domain>/*", zone_name = "<your-domain>" }
+]
+```
+
+Then `wrangler deploy` once more. The worker now runs on every request to `www.<your-domain>`.
+
+Your account manager notifies you when a new `worker.js` is available. Replace the file and re-run `wrangler deploy`. Secrets persist.
 
 ## Verify
 
 ```bash
-WORKER=https://your-worker.workers.dev
+WORKER=https://<name>.<your-subdomain>.workers.dev
 
-# HTML — should serve your origin (200)
+# 1. HTML — Protect should return "allow" (bootstrap-passthrough) and
+#    the worker forwards to your origin. Expected: 200, with
+#    x-prosopo-request-id in the response headers.
 curl -sD - -H "Accept: text/html" -H "User-Agent: Mozilla/5.0" "$WORKER/" | head
 
-# JSON, no cookie — should 401 with no-session status
+# 2. JSON, no cookie — Protect returns 401. Expected: 401,
+#    x-prosopo-status: no-session, x-prosopo-request-id.
 curl -sD - -H "Accept: application/json" "$WORKER/api/anything" | head
-# HTTP/2 401
-# x-prosopo-status: no-session
-# x-prosopo-request-id: <cf-ray>
 
-# From a proxy or VPN (only if you've enabled proxy/VPN blocking on
-# your Prosopo dashboard — see the next section) — should 403 with
-# the branded interstitial
-curl -sD - -H "Accept: text/html" -x http://your-proxy:port "$WORKER/" | head
-# HTTP/2 403
-# x-prosopo-decision: block
+# 3. POST /forms/* with Accept: text/html and no cookie — same 401.
+#    This closes the "spoof Accept: text/html on a POST to bypass
+#    session-required" bot pattern.
+curl -sD - -H "Accept: text/html" -X POST "$WORKER/forms/anything" | head
 ```
 
-`X-Prosopo-Request-Id` is echoed on every response and written to Protect's verdict audit log — grep from a support ticket straight to the verdict.
+**If command 1 returns anything but 200:** you may be hitting your own origin's bot protection, not Prosopo's. Cloudflare's Bot Management, AWS WAF, and similar tools reliably block curl regardless of what headers you set (they fingerprint TLS handshakes, not just User-Agents). Distinguish:
 
-## What the worker protects
+- **Response has `x-prosopo-*` headers** → the 4xx is from Prosopo. Check `x-prosopo-status` and `x-prosopo-decision` — see [Troubleshooting](/protect-edge/troubleshooting).
+- **Response has `server: cloudflare` / `server: awselb` / etc and no `x-prosopo-*` headers** → the 4xx is from your origin's own bot protection blocking curl. Verify command 1 with a real browser instead, or temporarily point `ORIGIN_URL` at `https://httpbin.org` for the workers.dev smoke test.
 
-The worker runs Protect logic on every request before serving anything. You can point it at:
+`X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log — quote it in support tickets and we can grep straight to the exact verdict that fired. The same ID also appears as `Reference: <id>` on the blocked interstitial page so users copying that line give you a direct lookup.
 
-- **Static assets** bound via `[assets]` in `wrangler.toml` (as in the example above). Set `run_worker_first = true` so the worker runs before Cloudflare's cache — without this, static files are served directly and Protect never sees the request.
-- **An upstream origin** — swap the assets binding for a `fetch(rewrittenUrl, request)` against your upstream, and set the origin host in `wrangler.toml`. The Protect decision above the fetch is unchanged.
+## Portal settings checklist
+
+Before deploying, confirm your Portal instance shows the settings you and your account manager agreed on. Open your [Prosopo dashboard](https://portal.prosopo.io/) → Sites → your site → Protect instance, and cross-check:
+
+| Setting | Typical value for a server-rendered site | Purpose |
+|--|--|--|
+| `cname` | `protect.<your-domain>` | Matches the DNS-only CNAME. If empty or pointing at `bumblebee1.prosopo.io`, the cert isn't wired up yet — talk to your account manager. |
+| `defaultPathType` | `html` | Server-rendered pages get the no-cookie bootstrap passthrough so first-time visitors can load the bundle. Set to `json` only if your site is a pure API. |
+| Endpoint rule: `/api/*` | `pathType: json` | Any XHR endpoint requires an established session. |
+| Endpoint rule: `/forms/*` | `pathType: json` | Form-action endpoints require a session. |
+| Thresholds | Challenge `0.5`, Block `0.85` | Prosopo defaults. Tune from the dashboard once you've seen a few days of real traffic. |
+| Enforcement | `onPending: allow`, `onChallenge: captcha`, `onError: allow` | Fail-open on transient errors — a Protect outage never blocks legitimate users. |
+| Captcha type | `frictionless` | Invisible on first attempt. Custom escalation (image challenge, PoW) can be layered on later. |
+| IP category rules | Typically `abuser: block`, `tor: block`; add `proxy: block` when you don't expect residential-proxy legitimate users | Conservative default. Every category rule can be tuned per site. |
+| Interstitial branding | Your logo, colours, copy strings | Rendered by the edge on block/challenge — sanitized server-side, no XSS risk. |
+
+If any of these don't match, contact your account manager before deploying. Settings drift here silently produces `401 no-session` on paths that should return `200`, or blocks IP categories you didn't intend to.
+
+## Deploying to production behind Cloudflare
+
+Once the workers.dev smoke tests are green, bind the worker to your production hostname by adding a route to `wrangler.toml`:
+
+```toml
+routes = [
+    { pattern = "www.<your-domain>/*", zone_name = "<your-domain>" }
+]
+```
+
+For the worker's forward to reach your origin you need **two hostnames**:
+
+- `www.<your-domain>` → orange-cloud through Cloudflare → this worker runs.
+- `origin.<your-domain>` → **grey-cloud** DNS-only, pointing at your real origin server. Set `ORIGIN_URL = "https://origin.<your-domain>"` in `wrangler.toml`.
+
+Pointing `ORIGIN_URL` at `www.<your-domain>` would send the forwarded request back through Cloudflare's edge — which routes it through this worker again — a loop.
+
+## Excluding static assets
+
+Every request through the worker costs a Protect API call. For hashed CSS/JS/image assets that never need a bot check, you can bypass Protect entirely using Cloudflare's `run_worker_first` list. Uncomment the `[assets]` block in the `wrangler.toml` example above, drop your files under `./public`, and any path matching a `!`-prefixed pattern is served by Cloudflare's asset worker without ever invoking Protect.
+
+Rule of thumb: exclude anything you'd normally cache aggressively on a CDN. Include everything a session should be established on (HTML pages, form endpoints, XHR/JSON endpoints).
 
 ## Configuring proxy, VPN and datacenter blocking
 
@@ -132,7 +274,7 @@ Protect's API calls from a Cloudflare Worker typically return in under 40 ms (un
 
 ## TLS caveats
 
-Cloudflare Workers doesn't expose a way to skip TLS verification on outbound fetches. If the Protect API URL you're configured with has an invalid or expired certificate, `fetch` returns HTTP 526 and Protect can't be reached. Point `BUMBLEBEE_URL` at a hostname with a valid certificate.
+Cloudflare Workers doesn't expose a way to skip TLS verification on outbound fetches. If the Protect API hostname doesn't have a valid certificate on our side yet, `fetch` returns HTTP 526 and Protect can't be reached. This is the failure mode when you deploy before your account manager has issued the cert for `protect.<your-domain>` — see [Coordinate cert issuance](#coordinate-cert-issuance-with-your-account-manager).
 
 ## Live logs
 
@@ -144,8 +286,4 @@ wrangler tail --format=pretty
 
 ## Troubleshooting
 
-- **`wrangler deploy` returns `Authentication error [code: 10000]`** — the token lacks **Workers Scripts: Read + Edit**. "Edit" alone isn't enough; wrangler needs both.
-- **Bundle deploys but every request 401s** — the `CLIENT_JWT` secret isn't set or has expired. Re-run `wrangler secret put CLIENT_JWT` and check `wrangler secret list`.
-- **HTTP 526 in `wrangler tail`** — the Protect API host's certificate is invalid or expired; see [TLS caveats](#tls-caveats).
-- **HTML `Access Denied` served instead of JSON on API paths** — the endpoint's declared content type is HTML. Update the site's `defaultPathType` (or add an endpoint rule) on your Prosopo dashboard.
-- **`Unknown site` in logs** — your site isn't registered with Protect. Check your dashboard or contact your account manager.
+Common failure modes with their causes are on the dedicated [Troubleshooting page](/protect-edge/troubleshooting).

--- a/src/content/docs/en/protect-edge/cloudflare-worker.mdx
+++ b/src/content/docs/en/protect-edge/cloudflare-worker.mdx
@@ -4,40 +4,39 @@ description: Deploy the Prosopo Protect Cloudflare Worker in front of your origi
 i18nReady: true
 ---
 
-The Prosopo Protect Cloudflare Worker sits in front of your origin and runs Protect's decision on every request. On `allow` it forwards to your origin; on `block` / `challenge` it returns immediately with a branded interstitial (or JSON error for API calls), no origin fetch.
+The Prosopo Protect Cloudflare Worker sits in front of your origin and runs Protect's decision on every request. On `allow` it forwards to your origin. On `block` or `challenge` it returns immediately with a branded interstitial (or JSON error for API calls) without touching your origin.
 
-## Two-part install — read this first
+## Two-part install: read this first
 
-A production Prosopo Protect integration is **two independent pieces working together**. Deploying only one leaves your site unprotected. Both are covered by this guide.
+A production Prosopo Protect integration is two independent pieces working together. Deploying only one leaves your site unprotected. Both are covered by this guide.
 
-1. **The Cloudflare Worker (server-side).** Sits in front of your origin. Runs the verdict on every request. Blocks bad traffic before it reaches your server. This is `worker.js` + `wrangler.toml`.
-
+1. **The Cloudflare Worker (server-side).** Sits in front of your origin, runs the verdict on every request, and blocks bad traffic before it reaches your server. This is `worker.js` plus `wrangler.toml`.
 2. **The Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the worker returns a challenge. This is a single `<script>` tag in your HTML.
 
-Without the worker, no request is scored. Without the bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the worker path only — a green worker with no bundle deployed **looks working** but every real user still fails on their first XHR.
+Without the worker, no request is scored. Without the bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the worker path only, so a green worker with no bundle deployed looks like it's working while every real user still fails on their first XHR.
 
 Deploy them in either order, but ship both before rollout.
 
 ## What you get
 
-- `worker.js` — the worker code, delivered per site and per environment. Self-contained, ~50 KB. Same file for every customer; per-site config lives in `wrangler.toml`.
-- `wrangler.toml` — deployment config, pre-set with your `PROTECT_URL`.
-- `README.md` — customer-specific quick reference mirroring this guide.
+- `worker.js`: the worker code, delivered per site and per environment. Self-contained, ~50 KB. Same file for every customer; per-site config lives in `wrangler.toml`.
+- `wrangler.toml`: deployment config, pre-set with your `PROTECT_URL`.
+- `README.md`: customer-specific quick reference mirroring this guide.
 
 ## Prerequisites
 
 - A Cloudflare account with an API token carrying:
-  - **Account → Workers Scripts → Edit** (upload the worker code).
-  - **Zone → Workers Routes → Edit** on the zone you'll bind the worker to (only needed when you move from `workers.dev` to a production route).
+  - **Account → Workers Scripts → Edit** to upload the worker code.
+  - **Zone → Workers Routes → Edit** on the zone you'll bind the worker to. Only needed when you move from `workers.dev` to a production route.
 - [`wrangler`](https://developers.cloudflare.com/workers/wrangler/install-and-update/) installed locally (`npm i -g wrangler`).
-- A Cloudflare zone for your production domain (a `workers.dev` subdomain is fine for the initial test).
+- A Cloudflare zone for your production domain. A `workers.dev` subdomain is fine for the initial test.
 - Your Prosopo account manager has:
-  - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding — see [Portal settings checklist](#portal-settings-checklist) below.
-  - Issued you a `CLIENT_JWT` (long-lived token authenticating the worker to the Protect API).
+  - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding. See [Portal settings checklist](#portal-settings-checklist) below.
+  - Issued you a `CLIENT_JWT`, a long-lived token authenticating the worker to the Protect API.
 
-## DNS: `protect.<your-domain>` as **DNS-only** (grey cloud)
+## DNS: `protect.<your-domain>` as DNS-only (grey cloud)
 
-The worker talks to Protect at a hostname you own — typically `protect.<your-domain>`. Create a CNAME record on that hostname pointing at Prosopo:
+The worker talks to Protect at a hostname you own, typically `protect.<your-domain>`. Create a CNAME record on that hostname pointing at Prosopo:
 
 ```
 protect.<your-domain>   CNAME   protect.prosopo.io
@@ -45,9 +44,9 @@ protect.<your-domain>   CNAME   protect.prosopo.io
 
 **Set the proxy status to DNS only (grey cloud), not proxied (orange cloud).** This is not optional.
 
-Why: Prosopo Protect's risk engine derives most of its bot-signal value from the raw TLS handshake — cipher-suite order, extensions, timing between packets (JA4, JA4H, JA4L, JA4T fingerprints). If Cloudflare's proxy terminates the browser's TLS at its edge, what reaches Prosopo is a fresh TLS connection from Cloudflare's own stack, identical for every user. The JA4 signals collapse to a single value and the risk-scoring pipeline degrades to noise.
+Why: Prosopo Protect's risk engine derives most of its bot-signal value from the raw TLS handshake (cipher-suite order, extensions, timing between packets, and the JA4, JA4H, JA4L, and JA4T fingerprints). If Cloudflare's proxy terminates the browser's TLS at its edge, what reaches Prosopo is a fresh TLS connection from Cloudflare's own stack, identical for every user. The JA4 signals collapse to a single value and the risk-scoring pipeline degrades to noise.
 
-Grey-cloud on `protect.<your-domain>` **only** — every other DNS record on your zone (including your main `www` record fronted by this worker) stays exactly as it is. This one subdomain needs to point directly at our origin so the browser's TLS handshake reaches us intact.
+Grey-cloud on `protect.<your-domain>` only. Every other DNS record on your zone (including your main `www` record fronted by this worker) stays exactly as it is. This one subdomain needs to point directly at our origin so the browser's TLS handshake reaches us intact.
 
 ### Coordinate cert issuance with your account manager
 
@@ -61,9 +60,9 @@ Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain vi
    # and an A record resolving directly to our edge (not Cloudflare's).
    ```
 
-   If the A record starts with `104.` or `172.` you're still orange-cloud — flip the record to grey-cloud before proceeding.
+   If the A record starts with `104.` or `172.` you're still orange-cloud. Flip the record to grey-cloud before proceeding.
 
-2. **Us**: email your account manager once DNS is grey-clouded and propagated. We issue the certificate on our end (~30 seconds), then confirm back. Attempting to deploy the worker before we've issued the cert results in HTTP 526 (SSL Handshake Failed) on every access-check call, and the worker fails open — no request is actually scored.
+2. **Us**: email your account manager once DNS is grey-clouded and propagated. We issue the certificate on our end (~30 seconds), then confirm back. Attempting to deploy the worker before we've issued the cert results in HTTP 526 (SSL Handshake Failed) on every access-check call, and the worker fails open. No request is actually scored.
 
 Once the cert is in place it auto-renews on our end every 60 days. You don't touch it again.
 
@@ -71,7 +70,7 @@ Once the cert is in place it auto-renews on our end every 60 days. You don't tou
 
 **This step is mandatory.** Without the bundle no session cookie is ever set, and the worker returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity.
 
-Add this snippet to every HTML page your site serves — a shared header or footer template is the usual spot:
+Add this snippet to every HTML page your site serves. A shared header or footer template is the usual spot:
 
 ```html
 <script>
@@ -83,7 +82,7 @@ Add this snippet to every HTML page your site serves — a shared header or foot
 <script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
 ```
 
-Both tags are required. The first sets `window.prosopo_config` before the second loads — the bundle reads that config to know which Protect API to talk to. Skipping the first tag causes the bundle to fall back to the CDN's own origin (`js.protect.prosopo.io`) as its API URL, which returns 405 on the CORS preflight for `/api/protect/init` and hangs the bundle's patched `fetch`.
+Both tags are required. The first sets `window.prosopo_config` before the second loads; the bundle reads that config to know which Protect API to talk to. Skipping the first tag causes the bundle to fall back to the CDN's own origin (`js.protect.prosopo.io`) as its API URL, which returns 405 on the CORS preflight for `/api/protect/init` and hangs the bundle's patched `fetch`.
 
 On first page load the bundle:
 
@@ -91,11 +90,11 @@ On first page load the bundle:
 2. Receives a `prosopo_session` cookie scoped to `.<your-domain>`.
 3. Loads a per-session telemetry runtime script that collects the bot-signal data used for risk scoring.
 
-Every subsequent request from that browser carries the cookie, and the worker looks up a real verdict on `/api/*` / `/forms/*` calls.
+Every subsequent request from that browser carries the cookie, and the worker looks up a real verdict on `/api/*` or `/forms/*` calls.
 
 ### Gate fast form submissions and link clicks (optional)
 
-Users can click **Submit** before the bundle finishes creating the session. The browser fires a full-page POST with no cookie and gets a 401. Security is correct — UX is bad.
+Users can click **Submit** before the bundle finishes creating the session. The browser fires a full-page POST with no cookie and gets a 401. The security is correct but the UX is bad.
 
 Opt any form or link into automatic held-until-session-ready behaviour by adding the `data-prosopo-gate` attribute:
 
@@ -110,9 +109,9 @@ Opt any form or link into automatic held-until-session-ready behaviour by adding
 </nav>
 ```
 
-The bundle intercepts marked forms / same-origin links in the capture phase, holds up to 8 seconds waiting for the session, then releases with the cookie in place. The submit button flips `disabled` + `aria-busy` while held so the user gets visual feedback. Ctrl/Cmd-click, middle-click, `target="_blank"`, `download` attributes, hash-only links, and cross-origin links are always passed through untouched.
+The bundle intercepts marked forms and same-origin links in the capture phase, holds up to 8 seconds waiting for the session, then releases with the cookie in place. The submit button flips `disabled` and `aria-busy` while held so the user gets visual feedback. Ctrl/Cmd-click, middle-click, `target="_blank"`, `download` attributes, hash-only links, and cross-origin links pass through untouched.
 
-Attributes on an ancestor cover every descendant form/link, so `<nav data-prosopo-gate>` gates every link inside.
+Attributes on an ancestor cover every descendant form or link, so `<nav data-prosopo-gate>` gates every link inside.
 
 ## Step 2: Deploy the worker
 
@@ -128,14 +127,14 @@ compatibility_flags = ["nodejs_compat"]
 PROTECT_URL = "https://protect.<your-domain>"
 # ORIGIN_URL is where the worker forwards allowed requests. Set this
 # for any deployment that fronts a real backend. Two hostnames are
-# required — the worker sits on <www>, forwards to a different name
+# required: the worker sits on <www>, forwards to a different name
 # (e.g. origin.<your-domain>, grey-clouded, pointing at your real
-# server) — pointing back at <www> would loop through this worker
+# server). Pointing back at <www> would loop through this worker
 # forever.
 ORIGIN_URL = "https://origin.<your-domain>"
 
 # Static assets are optional. Uncomment when the worker itself serves
-# files instead of forwarding to an origin (rare in production — the
+# files instead of forwarding to an origin (rare in production; the
 # origin usually serves them). `run_worker_first` uses positive
 # patterns for paths the worker runs on and `!`-prefixed patterns
 # for paths served directly (Protect entirely bypassed).
@@ -186,43 +185,43 @@ Your account manager notifies you when a new `worker.js` is available. Replace t
 ```bash
 WORKER=https://<name>.<your-subdomain>.workers.dev
 
-# 1. HTML — Protect should return "allow" (bootstrap-passthrough) and
+# 1. HTML: Protect should return "allow" (bootstrap-passthrough) and
 #    the worker forwards to your origin. Expected: 200, with
 #    x-prosopo-request-id in the response headers.
 curl -sD - -H "Accept: text/html" -H "User-Agent: Mozilla/5.0" "$WORKER/" | head
 
-# 2. JSON, no cookie — Protect returns 401. Expected: 401,
+# 2. JSON, no cookie: Protect returns 401. Expected: 401,
 #    x-prosopo-status: no-session, x-prosopo-request-id.
 curl -sD - -H "Accept: application/json" "$WORKER/api/anything" | head
 
-# 3. POST /forms/* with Accept: text/html and no cookie — same 401.
+# 3. POST /forms/* with Accept: text/html and no cookie: same 401.
 #    This closes the "spoof Accept: text/html on a POST to bypass
 #    session-required" bot pattern.
 curl -sD - -H "Accept: text/html" -X POST "$WORKER/forms/anything" | head
 ```
 
-**If command 1 returns anything but 200:** you may be hitting your own origin's bot protection, not Prosopo's. Cloudflare's Bot Management, AWS WAF, and similar tools reliably block curl regardless of what headers you set (they fingerprint TLS handshakes, not just User-Agents). Distinguish:
+**If command 1 returns anything other than 200**, you may be hitting your own origin's bot protection, not Prosopo's. Cloudflare Bot Management, AWS WAF, and similar tools reliably block curl regardless of what headers you set, because they fingerprint TLS handshakes rather than just User-Agents. Distinguish:
 
-- **Response has `x-prosopo-*` headers** → the 4xx is from Prosopo. Check `x-prosopo-status` and `x-prosopo-decision` — see [Troubleshooting](/protect-edge/troubleshooting).
-- **Response has `server: cloudflare` / `server: awselb` / etc and no `x-prosopo-*` headers** → the 4xx is from your origin's own bot protection blocking curl. Verify command 1 with a real browser instead, or temporarily point `ORIGIN_URL` at `https://httpbin.org` for the workers.dev smoke test.
+- If the response has `x-prosopo-*` headers, the 4xx is from Prosopo. Check `x-prosopo-status` and `x-prosopo-decision`. See [Troubleshooting](/protect-edge/troubleshooting).
+- If the response has `server: cloudflare` or `server: awselb` and no `x-prosopo-*` headers, the 4xx is from your origin's own bot protection blocking curl. Verify command 1 with a real browser instead, or temporarily point `ORIGIN_URL` at `https://httpbin.org` for the workers.dev smoke test.
 
-`X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log — quote it in support tickets and we can grep straight to the exact verdict that fired. The same ID also appears as `Reference: <id>` on the blocked interstitial page so users copying that line give you a direct lookup.
+`X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log. Quote it in support tickets and we can grep straight to the exact verdict that fired. The same ID also appears as `Reference: <id>` on the blocked interstitial page so users copying that line give you a direct lookup.
 
 ## Portal settings checklist
 
-Before deploying, confirm your Portal instance shows the settings you and your account manager agreed on. Open your [Prosopo dashboard](https://portal.prosopo.io/) → Sites → your site → Protect instance, and cross-check:
+Before deploying, confirm your Portal instance shows the settings you and your account manager agreed on. Open your [Prosopo dashboard](https://portal.prosopo.io/), navigate to Sites, your site, and Protect instance, and cross-check:
 
 | Setting | Typical value for a server-rendered site | Purpose |
 |--|--|--|
-| `cname` | `protect.<your-domain>` | Matches the DNS-only CNAME. If empty or pointing at `bumblebee1.prosopo.io`, the cert isn't wired up yet — talk to your account manager. |
+| `cname` | `protect.<your-domain>` | Matches the DNS-only CNAME. If empty or pointing at `bumblebee1.prosopo.io`, the cert isn't wired up yet; talk to your account manager. |
 | `defaultPathType` | `html` | Server-rendered pages get the no-cookie bootstrap passthrough so first-time visitors can load the bundle. Set to `json` only if your site is a pure API. |
 | Endpoint rule: `/api/*` | `pathType: json` | Any XHR endpoint requires an established session. |
 | Endpoint rule: `/forms/*` | `pathType: json` | Form-action endpoints require a session. |
 | Thresholds | Challenge `0.5`, Block `0.85` | Prosopo defaults. Tune from the dashboard once you've seen a few days of real traffic. |
-| Enforcement | `onPending: allow`, `onChallenge: captcha`, `onError: allow` | Fail-open on transient errors — a Protect outage never blocks legitimate users. |
+| Enforcement | `onPending: allow`, `onChallenge: captcha`, `onError: allow` | Fail-open on transient errors, so a Protect outage never blocks legitimate users. |
 | Captcha type | `frictionless` | Invisible on first attempt. Custom escalation (image challenge, PoW) can be layered on later. |
 | IP category rules | Typically `abuser: block`, `tor: block`; add `proxy: block` when you don't expect residential-proxy legitimate users | Conservative default. Every category rule can be tuned per site. |
-| Interstitial branding | Your logo, colours, copy strings | Rendered by the edge on block/challenge — sanitized server-side, no XSS risk. |
+| Interstitial branding | Your logo, colours, copy strings | Rendered by the edge on block/challenge, sanitized server-side, no XSS risk. |
 
 If any of these don't match, contact your account manager before deploying. Settings drift here silently produces `401 no-session` on paths that should return `200`, or blocks IP categories you didn't intend to.
 
@@ -238,25 +237,25 @@ routes = [
 
 For the worker's forward to reach your origin you need **two hostnames**:
 
-- `www.<your-domain>` → orange-cloud through Cloudflare → this worker runs.
-- `origin.<your-domain>` → **grey-cloud** DNS-only, pointing at your real origin server. Set `ORIGIN_URL = "https://origin.<your-domain>"` in `wrangler.toml`.
+- `www.<your-domain>`: orange-cloud through Cloudflare, so this worker runs.
+- `origin.<your-domain>`: **grey-cloud** DNS-only, pointing at your real origin server. Set `ORIGIN_URL = "https://origin.<your-domain>"` in `wrangler.toml`.
 
-Pointing `ORIGIN_URL` at `www.<your-domain>` would send the forwarded request back through Cloudflare's edge — which routes it through this worker again — a loop.
+Pointing `ORIGIN_URL` at `www.<your-domain>` would send the forwarded request back through Cloudflare's edge, which routes it through this worker again. That's a loop.
 
 ## Excluding static assets
 
-Every request through the worker costs a Protect API call. For hashed CSS/JS/image assets that never need a bot check, you can bypass Protect entirely using Cloudflare's `run_worker_first` list. Uncomment the `[assets]` block in the `wrangler.toml` example above, drop your files under `./public`, and any path matching a `!`-prefixed pattern is served by Cloudflare's asset worker without ever invoking Protect.
+Every request through the worker costs a Protect API call. For hashed CSS, JS, and image assets that never need a bot check, you can bypass Protect entirely using Cloudflare's `run_worker_first` list. Uncomment the `[assets]` block in the `wrangler.toml` example above, drop your files under `./public`, and any path matching a `!`-prefixed pattern is served by Cloudflare's asset worker without ever invoking Protect.
 
-Rule of thumb: exclude anything you'd normally cache aggressively on a CDN. Include everything a session should be established on (HTML pages, form endpoints, XHR/JSON endpoints).
+Rule of thumb: exclude anything you'd normally cache aggressively on a CDN. Include everything a session should be established on (HTML pages, form endpoints, XHR and JSON endpoints).
 
 ## Configuring proxy, VPN and datacenter blocking
 
 Blocking policy lives on your [Prosopo dashboard](https://portal.prosopo.io/), not in the bundle. Two independent rule sources feed the no-cookie edge path:
 
-- **Site settings** — recognised IP categories: `tor`, `datacenter`, `proxy`, `vpn`, `abuser`, `mobile`, `crawler`. Configure per-category verdicts (`allow` / `challenge` / `block`).
-- **Tiered access rules** — support the full rule set: IP CIDR, ASN, IP category, country, User-Agent substring, JA4 TLS fingerprint. Rules can be scoped to your site or applied globally by Prosopo.
+- **Site settings**: recognised IP categories are `tor`, `datacenter`, `proxy`, `vpn`, `abuser`, `mobile`, and `crawler`. Configure per-category verdicts (`allow`, `challenge`, or `block`).
+- **Tiered access rules**: support the full rule set of IP CIDR, ASN, IP category, country, User-Agent substring, and JA4 TLS fingerprint. Rules can be scoped to your site or applied globally by Prosopo.
 
-Either source firing blocks the request at the edge. When both match, the more restrictive verdict wins (`Block > Challenge > Allow`). Policy changes take effect on the next request — no redeploy needed.
+Either source firing blocks the request at the edge. When both match, the more restrictive verdict wins (`Block > Challenge > Allow`). Policy changes take effect on the next request, no redeploy needed.
 
 ## Rotating credentials
 
@@ -270,11 +269,11 @@ The next request picks up the new value.
 
 ## Performance
 
-Protect's API calls from a Cloudflare Worker typically return in under 40 ms (under 2 ms for cached lookups) and are budgeted to a 500 ms hard timeout, with fail-open on transient errors. On an `allow` verdict the request continues to your origin as normal; on `block` or `challenge` the worker returns immediately without an origin fetch, so protected requests are strictly faster than unprotected ones for the blocked path.
+Protect's API calls from a Cloudflare Worker typically return in under 40 ms (under 2 ms for cached lookups) and are budgeted to a 500 ms hard timeout, with fail-open on transient errors. On an `allow` verdict the request continues to your origin as normal. On `block` or `challenge` the worker returns immediately without an origin fetch, so protected requests are strictly faster than unprotected ones for the blocked path.
 
 ## TLS caveats
 
-Cloudflare Workers doesn't expose a way to skip TLS verification on outbound fetches. If the Protect API hostname doesn't have a valid certificate on our side yet, `fetch` returns HTTP 526 and Protect can't be reached. This is the failure mode when you deploy before your account manager has issued the cert for `protect.<your-domain>` — see [Coordinate cert issuance](#coordinate-cert-issuance-with-your-account-manager).
+Cloudflare Workers doesn't expose a way to skip TLS verification on outbound fetches. If the Protect API hostname doesn't have a valid certificate on our side yet, `fetch` returns HTTP 526 and Protect can't be reached. This is the failure mode when you deploy before your account manager has issued the cert for `protect.<your-domain>`. See [Coordinate cert issuance](#coordinate-cert-issuance-with-your-account-manager).
 
 ## Live logs
 

--- a/src/content/docs/en/protect-edge/cloudflare-worker.mdx
+++ b/src/content/docs/en/protect-edge/cloudflare-worker.mdx
@@ -19,9 +19,13 @@ Deploy the two parts in either order, but ship both before rollout. The sections
 
 ## What you get
 
-- `worker.js`: the worker code, delivered per site and per environment. Self-contained, ~50 KB. Same file for every customer; per-site config lives in `wrangler.toml`.
-- `wrangler.toml`: deployment config, pre-set with your `PROTECT_URL`.
+Part 1 (server-side) is delivered as a zip:
+
+- `worker.js`: the worker code. Self-contained, ~50 KB. Same file for every customer; per-site config lives in `wrangler.toml`.
+- `wrangler.toml`: Cloudflare deployment config, pre-set with your `PROTECT_URL`.
 - `README.md`: customer-specific quick reference mirroring this guide.
+
+Part 2 (client-side) is hosted by us. You add one `<script>` tag pointing at `https://js.protect.prosopo.io/protect.bundle.js`. Nothing to download or bundle yourself. We publish new versions to that URL; your pages pick them up on their next reload without a redeploy from you.
 
 ## Prerequisites
 

--- a/src/content/docs/en/protect-edge/cloudflare-worker.mdx
+++ b/src/content/docs/en/protect-edge/cloudflare-worker.mdx
@@ -8,14 +8,14 @@ The Prosopo Protect Cloudflare Worker sits in front of your origin and runs Prot
 
 ## Two-part install: read this first
 
-A production Prosopo Protect integration is two independent pieces working together. Deploying only one leaves your site unprotected. Both are covered by this guide.
+A production Prosopo Protect integration is two independent pieces working together. Deploying only one leaves your site unprotected:
 
-1. **The Cloudflare Worker (server-side).** Sits in front of your origin, runs the verdict on every request, and blocks bad traffic before it reaches your server. This is `worker.js` plus `wrangler.toml`.
-2. **The Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the worker returns a challenge. This is a single `<script>` tag in your HTML.
+- **Part 1: the Cloudflare Worker (server-side).** Sits in front of your origin, runs the verdict on every request, and blocks bad traffic before it reaches your server. This is `worker.js` plus `wrangler.toml`.
+- **Part 2: the Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the worker returns a challenge. This is a single `<script>` tag in your HTML.
 
-Without the worker, no request is scored. Without the bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the worker path only, so a green worker with no bundle deployed looks like it's working while every real user still fails on their first XHR.
+Without the worker, no request is scored. Without the bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands under Part 1 test the worker path only, so a green worker with no bundle deployed looks like it's working while every real user still fails on their first XHR.
 
-Deploy them in either order, but ship both before rollout.
+Deploy the two parts in either order, but ship both before rollout. The sections below are organised under the same two headings.
 
 ## What you get
 
@@ -34,7 +34,9 @@ Deploy them in either order, but ship both before rollout.
   - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding. See [Portal settings checklist](#portal-settings-checklist) below.
   - Issued you a `CLIENT_JWT`, a long-lived token authenticating the worker to the Protect API.
 
-## DNS: `protect.<your-domain>` as DNS-only (grey cloud)
+## Part 1: the Cloudflare Worker (server-side)
+
+### 1a. DNS: `protect.<your-domain>` as DNS-only (grey cloud)
 
 The worker talks to Protect at a hostname you own, typically `protect.<your-domain>`. Create a CNAME record on that hostname pointing at Prosopo:
 
@@ -48,7 +50,7 @@ Why: Prosopo Protect's risk engine derives most of its bot-signal value from the
 
 Grey-cloud on `protect.<your-domain>` only. Every other DNS record on your zone (including your main `www` record fronted by this worker) stays exactly as it is. This one subdomain needs to point directly at our origin so the browser's TLS handshake reaches us intact.
 
-### Coordinate cert issuance with your account manager
+### 1b. Coordinate cert issuance with your account manager
 
 Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain via Let's Encrypt on our infrastructure. This is a two-step handoff:
 
@@ -66,54 +68,7 @@ Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain vi
 
 Once the cert is in place it auto-renews on our end every 60 days. You don't touch it again.
 
-## Step 1: Add the Protect JS bundle to every HTML page
-
-**This step is mandatory.** Without the bundle no session cookie is ever set, and the worker returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity.
-
-Add this snippet to every HTML page your site serves. A shared header or footer template is the usual spot:
-
-```html
-<script>
-  window.prosopo_config = {
-    site_key: "<your-site-key>",
-    protect_url: "https://protect.<your-domain>"
-  };
-</script>
-<script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
-```
-
-Both tags are required. The first sets `window.prosopo_config` before the second loads; the bundle reads that config to know which Protect API to talk to. Skipping the first tag causes the bundle to fall back to the CDN's own origin (`js.protect.prosopo.io`) as its API URL, which returns 405 on the CORS preflight for `/api/protect/init` and hangs the bundle's patched `fetch`.
-
-On first page load the bundle:
-
-1. Calls `POST https://protect.<your-domain>/api/protect/init`.
-2. Receives a `prosopo_session` cookie scoped to `.<your-domain>`.
-3. Loads a per-session telemetry runtime script that collects the bot-signal data used for risk scoring.
-
-Every subsequent request from that browser carries the cookie, and the worker looks up a real verdict on `/api/*` or `/forms/*` calls.
-
-### Gate fast form submissions and link clicks (optional)
-
-Users can click **Submit** before the bundle finishes creating the session. The browser fires a full-page POST with no cookie and gets a 401. The security is correct but the UX is bad.
-
-Opt any form or link into automatic held-until-session-ready behaviour by adding the `data-prosopo-gate` attribute:
-
-```html
-<form action="/forms/search.php" method="post" data-prosopo-gate>
-  <!-- ... -->
-</form>
-
-<nav data-prosopo-gate>
-  <a href="/section-a/">Section A</a>
-  <a href="/section-b/">Section B</a>
-</nav>
-```
-
-The bundle intercepts marked forms and same-origin links in the capture phase, holds up to 8 seconds waiting for the session, then releases with the cookie in place. The submit button flips `disabled` and `aria-busy` while held so the user gets visual feedback. Ctrl/Cmd-click, middle-click, `target="_blank"`, `download` attributes, hash-only links, and cross-origin links pass through untouched.
-
-Attributes on an ancestor cover every descendant form or link, so `<nav data-prosopo-gate>` gates every link inside.
-
-## Step 2: Deploy the worker
+### 1c. Deploy the worker
 
 Cloudflare Workers is configured by a `wrangler.toml` alongside the worker code:
 
@@ -168,7 +123,7 @@ echo "<your-CLIENT_JWT>" | wrangler secret put CLIENT_JWT
 wrangler deploy
 ```
 
-The worker is now live at `https://<name>.<your-subdomain>.workers.dev`. Once the verify commands below all pass, attach it to your production hostname by uncommenting the `routes` block in `wrangler.toml`:
+The worker is now live at `https://<name>.<your-subdomain>.workers.dev`. Once the verify commands below pass, attach it to your production hostname by uncommenting the `routes` block in `wrangler.toml`:
 
 ```toml
 routes = [
@@ -180,7 +135,7 @@ Then `wrangler deploy` once more. The worker now runs on every request to `www.<
 
 Your account manager notifies you when a new `worker.js` is available. Replace the file and re-run `wrangler deploy`. Secrets persist.
 
-## Verify
+### 1d. Verify the worker
 
 ```bash
 WORKER=https://<name>.<your-subdomain>.workers.dev
@@ -206,6 +161,67 @@ curl -sD - -H "Accept: text/html" -X POST "$WORKER/forms/anything" | head
 - If the response has `server: cloudflare` or `server: awselb` and no `x-prosopo-*` headers, the 4xx is from your origin's own bot protection blocking curl. Verify command 1 with a real browser instead, or temporarily point `ORIGIN_URL` at `https://httpbin.org` for the workers.dev smoke test.
 
 `X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log. Quote it in support tickets and we can grep straight to the exact verdict that fired. The same ID also appears as `Reference: <id>` on the blocked interstitial page so users copying that line give you a direct lookup.
+
+Worker verified? Move to Part 2.
+
+## Part 2: the Protect JS bundle (client-side)
+
+**This part is mandatory.** Without the bundle no session cookie is ever set, and the worker returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity. The worker verify commands under Part 1 still pass without the bundle; real user traffic doesn't.
+
+### 2a. Add the script tag to every HTML page
+
+Add this snippet to every HTML page your site serves. A shared header or footer template is the usual spot:
+
+```html
+<script>
+  window.prosopo_config = {
+    site_key: "<your-site-key>",
+    protect_url: "https://protect.<your-domain>"
+  };
+</script>
+<script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
+```
+
+Both tags are required. The first sets `window.prosopo_config` before the second loads; the bundle reads that config to know which Protect API to talk to. Skipping the first tag causes the bundle to fall back to the CDN's own origin (`js.protect.prosopo.io`) as its API URL, which returns 405 on the CORS preflight for `/api/protect/init` and hangs the bundle's patched `fetch`.
+
+On first page load the bundle:
+
+1. Calls `POST https://protect.<your-domain>/api/protect/init`.
+2. Receives a `prosopo_session` cookie scoped to `.<your-domain>`.
+3. Loads a per-session telemetry runtime script that collects the bot-signal data used for risk scoring.
+
+Every subsequent request from that browser carries the cookie, and the worker looks up a real verdict on `/api/*` or `/forms/*` calls.
+
+### 2b. Gate fast form submissions and link clicks (optional)
+
+Users can click **Submit** before the bundle finishes creating the session. The browser fires a full-page POST with no cookie and gets a 401. The security is correct but the UX is bad.
+
+Opt any form or link into automatic held-until-session-ready behaviour by adding the `data-prosopo-gate` attribute:
+
+```html
+<form action="/forms/search.php" method="post" data-prosopo-gate>
+  <!-- ... -->
+</form>
+
+<nav data-prosopo-gate>
+  <a href="/section-a/">Section A</a>
+  <a href="/section-b/">Section B</a>
+</nav>
+```
+
+The bundle intercepts marked forms and same-origin links in the capture phase, holds up to 8 seconds waiting for the session, then releases with the cookie in place. The submit button flips `disabled` and `aria-busy` while held so the user gets visual feedback. Ctrl/Cmd-click, middle-click, `target="_blank"`, `download` attributes, hash-only links, and cross-origin links pass through untouched.
+
+Attributes on an ancestor cover every descendant form or link, so `<nav data-prosopo-gate>` gates every link inside.
+
+### 2c. Verify the bundle
+
+Open your site in a real browser with DevTools on the Network tab. On first page load you should see:
+
+- A `POST` to `https://protect.<your-domain>/api/protect/init` returning `200` and a `Set-Cookie: prosopo_session=…` header.
+- A subsequent `GET https://protect.<your-domain>/api/protect/t/<jti>` fetching the per-session telemetry runtime.
+- The `prosopo_session` cookie set with `Domain=.<your-domain>` for later requests.
+
+If the init call goes to `https://js.protect.prosopo.io/api/protect/init` and returns 405, the `window.prosopo_config` block is missing from the snippet. See [Troubleshooting](/protect-edge/troubleshooting#http-401-no-session-on-every-user-request).
 
 ## Portal settings checklist
 
@@ -273,7 +289,7 @@ Protect's API calls from a Cloudflare Worker typically return in under 40 ms (un
 
 ## TLS caveats
 
-Cloudflare Workers doesn't expose a way to skip TLS verification on outbound fetches. If the Protect API hostname doesn't have a valid certificate on our side yet, `fetch` returns HTTP 526 and Protect can't be reached. This is the failure mode when you deploy before your account manager has issued the cert for `protect.<your-domain>`. See [Coordinate cert issuance](#coordinate-cert-issuance-with-your-account-manager).
+Cloudflare Workers doesn't expose a way to skip TLS verification on outbound fetches. If the Protect API hostname doesn't have a valid certificate on our side yet, `fetch` returns HTTP 526 and Protect can't be reached. This is the failure mode when you deploy before your account manager has issued the cert for `protect.<your-domain>`. See [Coordinate cert issuance](#1b-coordinate-cert-issuance-with-your-account-manager).
 
 ## Live logs
 

--- a/src/content/docs/en/protect-edge/index.mdx
+++ b/src/content/docs/en/protect-edge/index.mdx
@@ -6,46 +6,46 @@ i18nReady: true
 
 Prosopo Protect can run at the edge of your CDN so blocked and challenged requests never reach your origin. Two integrations are supported today:
 
-- **[Cloudflare Workers](/protect-edge/cloudflare-worker)** — deploy alongside your Cloudflare zone.
-- **[AWS Lambda@Edge](/protect-edge/lambda-edge)** — deploy in front of a CloudFront distribution.
+- **[Cloudflare Workers](/protect-edge/cloudflare-worker)**: deploy alongside your Cloudflare zone.
+- **[AWS Lambda@Edge](/protect-edge/lambda-edge)**: deploy in front of a CloudFront distribution.
 
-Both integrations enforce the same policy: they consult the Prosopo Protect API on every incoming request and act on the returned verdict before it reaches your origin.
+Both integrations enforce the same policy. They consult the Prosopo Protect API on every incoming request and act on the returned verdict before it reaches your origin.
 
 ## How it works
 
 On every request that hits your CDN:
 
-1. **If the request has a `prosopo_session` cookie** the edge fetches the verdict for the session's token from the Prosopo Protect API. `allow` passes through to your origin; `block` returns a branded interstitial (or JSON error for API calls) with no origin fetch; `challenge` serves a captcha interstitial.
-2. **If the request has no cookie** the edge asks Protect what to do. Protect evaluates your access-rule set (IP CIDR, ASN, IP category, country, User-Agent, JA4 TLS fingerprint) against the request. Rule matches return `block` or `challenge`; if no rule matches and the path is an HTML page, the edge lets it through so the Protect script can create a session.
+1. **If the request has a `prosopo_session` cookie**, the edge fetches the verdict for the session's token from the Prosopo Protect API. `allow` passes through to your origin. `block` returns a branded interstitial (or JSON error for API calls) with no origin fetch. `challenge` serves a captcha interstitial.
+2. **If the request has no cookie**, the edge asks Protect what to do. Protect evaluates your access-rule set (IP CIDR, ASN, IP category, country, User-Agent, JA4 TLS fingerprint) against the request. Rule matches return `block` or `challenge`. If no rule matches and the path is an HTML page, the edge lets it through so the Protect script can create a session.
 
-The blocked-response HTML and challenge interstitial are branded per site via your Prosopo dashboard: logo, colour palette, typography, and message strings all sanitised and rendered server-side by the edge.
+The blocked-response HTML and challenge interstitial are branded per site via your Prosopo dashboard: logo, colour palette, typography, and message strings, all sanitised and rendered server-side by the edge.
 
 ## Protecting HTML pages vs JSON APIs
 
 Protect handles browser page loads and API calls differently. You tell it which paths on your site are which, and the edge enforces accordingly.
 
-### HTML paths — pages users load in a browser
+### HTML paths: pages users load in a browser
 
 - **First visit (no cookie):** the edge passes the request through so the Protect script embedded in your HTML can load and create a session.
 - **Subsequent requests:** the edge fetches the verdict and either forwards (`allow`), serves a captcha interstitial (`challenge`), or serves a branded "Access Denied" page (`block`).
 
-Session creation is transparent — the Protect script calls `/api/protect/init`, receives a `prosopo_session` cookie, and every request from that browser carries it automatically.
+Session creation is transparent. The Protect script calls `/api/protect/init`, receives a `prosopo_session` cookie, and every request from that browser carries it automatically.
 
-### JSON paths — API endpoints called by scripts / XHR / `fetch`
+### JSON paths: API endpoints called by scripts, XHR, or `fetch`
 
 - **No cookie:** the edge returns **401 Unauthorized** with `X-Prosopo-Status: no-session`. The Protect script (loaded on your site's HTML pages) intercepts the 401, creates a session, and replays the request.
-- **With cookie:** the edge fetches the verdict. `allow` forwards to your origin; `block` returns a JSON error the Protect script uses to render an in-place block interstitial; `challenge` returns a JSON `challenge_config` the script uses to render a captcha modal without a full-page reload.
+- **With cookie:** the edge fetches the verdict. `allow` forwards to your origin. `block` returns a JSON error the Protect script uses to render an in-place block interstitial. `challenge` returns a JSON `challenge_config` the script uses to render a captcha modal without a full-page reload.
 
-JSON paths never pass through on a cookie-less request — an API endpoint isn't an HTML page, so there's nowhere for the Protect script to load from and no session can be bootstrapped on the fly. A first-hit is always either a rule-based decision or a hard 401.
+JSON paths never pass through on a cookie-less request. An API endpoint isn't an HTML page, so there's nowhere for the Protect script to load from and no session can be bootstrapped on the fly. A first-hit is always either a rule-based decision or a hard 401.
 
 ### Configuring path types
 
 Tell Protect which paths on your site are HTML vs JSON on your [Prosopo dashboard](https://portal.prosopo.io/):
 
-- **Site-level default (`defaultPathType`)** — applies to every path unless overridden.
-- **Per-endpoint rules** — override the default for specific paths (e.g. `/api/*` → json, `/` → html).
+- **Site-level default (`defaultPathType`)**: applies to every path unless overridden.
+- **Per-endpoint rules**: override the default for specific paths (e.g. `/api/*` → json, `/` → html).
 
-This closes the "spoof `Accept: text/html` on an API endpoint" bypass. Bots can lie about their `Accept` header, but they can't change what content type your site actually serves at a given path — the declared type is what the edge enforces.
+This closes the "spoof `Accept: text/html` on an API endpoint" bypass. Bots can lie about their `Accept` header, but they can't change what content type your site actually serves at a given path. The declared type is what the edge enforces.
 
 ### Which mode fits your site
 
@@ -55,7 +55,7 @@ This closes the "spoof `Accept: text/html` on an API endpoint" bypass. Bots can 
 | Single-page app with a heavy API surface | `json` | `/`, `/index.html` → `html` |
 | Pure JSON API service (no HTML at all) | `json` | (none) |
 
-For a pure-API deployment, consumers must obtain a session through a separate app that loads the Protect script, or through your own headless-friendly flow — the edge won't let a cookie-less browser reach a JSON endpoint.
+For a pure-API deployment, consumers must obtain a session through a separate app that loads the Protect script, or through your own headless-friendly flow. The edge won't let a cookie-less browser reach a JSON endpoint.
 
 ## Correlation
 
@@ -63,19 +63,19 @@ Every edge request is stamped with an `X-Prosopo-Request-Id` header that's echoe
 
 ## Two-part install
 
-Both edge integrations are **two independent pieces working together**, and deploying only one leaves your site unprotected:
+Both edge integrations are two independent pieces working together, and deploying only one leaves your site unprotected:
 
-1. **The edge worker (server-side).** Sits in front of your origin. Runs the verdict on every request. Blocks bad traffic before it reaches your server.
+1. **The edge worker (server-side).** Sits in front of your origin, runs the verdict on every request, and blocks bad traffic before it reaches your server.
 2. **The Protect JS bundle (client-side).** Loaded on every HTML page. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the edge returns a challenge.
 
-Without the worker, no request is scored. Without the JS bundle, no user ever gets a session cookie — every `/api/*` and `/forms/*` request returns 401 `no-session` forever, because there is no session to look up. Both are covered by each platform's install guide.
+Without the worker, no request is scored. Without the JS bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever, because there is no session to look up. Both are covered by each platform's install guide.
 
 ## What's next
 
 Pick your platform:
 
-- **[Cloudflare Worker](/protect-edge/cloudflare-worker)** — install, configure, deploy, verify.
-- **[AWS Lambda@Edge](/protect-edge/lambda-edge)** — same policy, deployed in front of CloudFront.
-- **[Troubleshooting](/protect-edge/troubleshooting)** — distinguish Prosopo 4xx from your other bot-protection layers, recognise known-benign console warnings, diagnose the common misconfigurations.
+- **[Cloudflare Worker](/protect-edge/cloudflare-worker)**: install, configure, deploy, verify.
+- **[AWS Lambda@Edge](/protect-edge/lambda-edge)**: same policy, deployed in front of CloudFront.
+- **[Troubleshooting](/protect-edge/troubleshooting)**: distinguish Prosopo 4xx from your other bot-protection layers, recognise known-benign console warnings, diagnose the common misconfigurations.
 
-Before you deploy, your Prosopo site must be registered with the Protect service. Site registration is handled from your [Prosopo dashboard](https://portal.prosopo.io/) or by your Prosopo account manager — you will need the site's SS58 key (e.g. `5HSuC1s…`) and a `CLIENT_JWT` signed by the site's key to authenticate the edge to the Protect API.
+Before you deploy, your Prosopo site must be registered with the Protect service. Site registration is handled from your [Prosopo dashboard](https://portal.prosopo.io/) or by your Prosopo account manager. You will need the site's SS58 key (e.g. `5HSuC1s…`) and a `CLIENT_JWT` signed by the site's key to authenticate the edge to the Protect API.

--- a/src/content/docs/en/protect-edge/index.mdx
+++ b/src/content/docs/en/protect-edge/index.mdx
@@ -61,11 +61,21 @@ For a pure-API deployment, consumers must obtain a session through a separate ap
 
 Every edge request is stamped with an `X-Prosopo-Request-Id` header that's echoed on the response and written to the verdict audit log. From a support ticket you can grep straight to the verdict that fired.
 
+## Two-part install
+
+Both edge integrations are **two independent pieces working together**, and deploying only one leaves your site unprotected:
+
+1. **The edge worker (server-side).** Sits in front of your origin. Runs the verdict on every request. Blocks bad traffic before it reaches your server.
+2. **The Protect JS bundle (client-side).** Loaded on every HTML page. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the edge returns a challenge.
+
+Without the worker, no request is scored. Without the JS bundle, no user ever gets a session cookie — every `/api/*` and `/forms/*` request returns 401 `no-session` forever, because there is no session to look up. Both are covered by each platform's install guide.
+
 ## What's next
 
 Pick your platform:
 
 - **[Cloudflare Worker](/protect-edge/cloudflare-worker)** — install, configure, deploy, verify.
 - **[AWS Lambda@Edge](/protect-edge/lambda-edge)** — same policy, deployed in front of CloudFront.
+- **[Troubleshooting](/protect-edge/troubleshooting)** — distinguish Prosopo 4xx from your other bot-protection layers, recognise known-benign console warnings, diagnose the common misconfigurations.
 
 Before you deploy, your Prosopo site must be registered with the Protect service. Site registration is handled from your [Prosopo dashboard](https://portal.prosopo.io/) or by your Prosopo account manager — you will need the site's SS58 key (e.g. `5HSuC1s…`) and a `CLIENT_JWT` signed by the site's key to authenticate the edge to the Protect API.

--- a/src/content/docs/en/protect-edge/lambda-edge.mdx
+++ b/src/content/docs/en/protect-edge/lambda-edge.mdx
@@ -4,41 +4,80 @@ description: Deploy the Prosopo Protect Lambda@Edge bundle in front of a CloudFr
 i18nReady: true
 ---
 
-The Prosopo Protect Lambda@Edge bundle runs on Amazon CloudFront's viewer-request trigger. It executes Protect's decision on every request and either forwards the request to your origin (`allow`), blocks it with a branded interstitial (`block`), or serves a captcha challenge (`challenge`).
+The Prosopo Protect Lambda@Edge bundle runs on Amazon CloudFront's viewer-request trigger. It executes Protect's decision on every request and either forwards to your origin (`allow`), blocks it with a branded interstitial (`block`), or serves a captcha challenge (`challenge`).
+
+## Two-part install — read this first
+
+A production Prosopo Protect integration is **two independent pieces working together**. Deploying only one leaves your site unprotected. Both are covered by this guide.
+
+1. **The Lambda@Edge bundle (server-side).** Runs on every CloudFront viewer request. Executes the verdict, blocks bad traffic before it reaches your origin. This is `lambda-edge.js`, deployed as a Lambda function and attached to a CloudFront behaviour.
+
+2. **The Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the edge returns a challenge. This is a single `<script>` tag in your HTML.
+
+Without the Lambda, no request is scored. Without the JS bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the Lambda path only — a green Lambda with no JS bundle deployed **looks working** but every real user still fails on their first XHR.
+
+Deploy them in either order, but ship both before rollout.
 
 ## What you get
 
-A single JavaScript file, `lambda-edge.js`, delivered per site and per environment. It's self-contained — no dependencies, no configuration, ~100 KB.
+- `lambda-edge.js` — the bundle, delivered per site and per environment. Self-contained, ~100 KB. Same file for every customer; per-site config is baked in at build time.
 
 ## Prerequisites
 
 - An AWS account with permission to create Lambda functions in **`us-east-1`** (Lambda@Edge functions must live there), publish versions of that function, and attach viewer-request triggers to your CloudFront distributions.
 - A CloudFront distribution serving your origin.
 - The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) or the AWS Console.
-- A CNAME record for your Protect API hostname — see the next section.
+- Your Prosopo account manager has:
+  - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding — see [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist) (same list applies here).
+  - Issued you a bundle scoped to your site.
 
-## DNS: point your Protect subdomain at Prosopo
+## DNS: `protect.<your-domain>` as **DNS-only**
 
-The bundle talks to your Protect API over HTTPS at a hostname you own — typically `protect.<your-domain>`. Create a CNAME record on your DNS pointing that hostname at Prosopo:
+The bundle talks to Protect at a hostname you own — typically `protect.<your-domain>`. Create a CNAME record on your DNS pointing that hostname at Prosopo:
 
 ```
 protect.<your-domain>   CNAME   protect.prosopo.io
 ```
 
-Then enter the same hostname (e.g. `protect.example.com`) in the **CNAME** field of your site's Protect settings on your [Prosopo dashboard](https://portal.prosopo.io/). Prosopo uses this to route TLS requests arriving at that SNI to your site's configuration.
+**Do not put this record behind a proxy layer (CloudFront, Cloudflare, or similar).** Prosopo's risk engine derives most of its bot-signal value from the raw TLS handshake (JA4/JA4H/JA4L/JA4T fingerprints). If a proxy terminates the browser's TLS at its edge and re-opens a fresh connection to Prosopo, the JA4 signals collapse to a single value per proxy stack and risk scoring degrades to noise. This subdomain must be DNS-only.
 
-The bundle you receive from Prosopo is built against your CNAMEd hostname — you don't need to configure the URL yourself. If you rotate the CNAMEd hostname, request a fresh bundle. TLS certificate handling is managed by Prosopo automatically for the CNAMEd hostname.
+### Coordinate cert issuance with your account manager
 
-Verify the DNS is live before deploying the bundle:
+Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain via Let's Encrypt on our infrastructure. This is a two-step handoff:
 
-```bash
-dig protect.<your-domain>
-# should show a CNAME to protect.prosopo.io and an A record.
+1. **You**: create the CNAME record. Verify it's live:
+
+   ```bash
+   dig protect.<your-domain>
+   # ANSWER SECTION should show a CNAME to protect.prosopo.io
+   # and an A record resolving directly to our edge.
+   ```
+
+2. **Us**: email your account manager once DNS is propagated. We issue the certificate on our end (~30 seconds), then confirm back. Attempting to deploy the Lambda before we've issued the cert results in TLS handshake failures on every access-check call, and the Lambda fails open — no request is actually scored.
+
+Once the cert is in place it auto-renews on our end every 60 days.
+
+The bundle you receive from Prosopo is built against your CNAMEd hostname — you don't need to configure the URL yourself. If you rotate the CNAMEd hostname, request a fresh bundle.
+
+## Step 1: Add the Protect JS bundle to every HTML page
+
+**This step is mandatory.** Without the bundle no session cookie is ever set, and the Lambda returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity.
+
+Add this snippet to every HTML page your site serves — a shared header or footer template is the usual spot:
+
+```html
+<script>
+  window.prosopo_config = {
+    site_key: "<your-site-key>",
+    protect_url: "https://protect.<your-domain>"
+  };
+</script>
+<script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
 ```
 
-**Do not use NS delegation.** Only a CNAME record is supported; NS would delegate the whole subdomain to Prosopo's nameservers, which isn't the model.
+Both tags are required. See the [Cloudflare Worker guide](/protect-edge/cloudflare-worker#step-1-add-the-protect-js-bundle-to-every-html-page) for a full explanation of what each tag does and how to gate fast form submissions with `data-prosopo-gate`.
 
-## Deploy
+## Step 2: Deploy the Lambda
 
 Upload the bundle to Lambda, publish a version, and attach the versioned ARN to the CloudFront behaviour you want to protect.
 
@@ -104,24 +143,26 @@ Once the trigger is attached and CloudFront has propagated, test through the dis
 ```bash
 DIST=https://your-distribution.cloudfront.net
 
-# HTML — should serve your origin (200)
+# 1. HTML — Protect should return "allow" (bootstrap-passthrough) and
+#    CloudFront forwards to your origin. Expected: 200, with
+#    x-prosopo-request-id in the response headers.
 curl -sD - -H "Accept: text/html" -H "User-Agent: Mozilla/5.0" "$DIST/" | head
 
-# JSON, no cookie — should 401 with no-session status
+# 2. JSON, no cookie — Protect returns 401. Expected: 401,
+#    x-prosopo-status: no-session, x-prosopo-request-id.
 curl -sD - -H "Accept: application/json" "$DIST/api/anything" | head
-# HTTP/2 401
-# x-prosopo-status: no-session
-# x-prosopo-request-id: <cloudfront-request-id>
 
-# From a proxy or VPN (only if you've enabled proxy/VPN blocking on
-# your Prosopo dashboard — see the next section) — should 403 with
-# the branded interstitial
-curl -sD - -H "Accept: text/html" -x http://your-proxy:port "$DIST/" | head
-# HTTP/2 403
-# x-prosopo-decision: block
+# 3. POST /forms/* with Accept: text/html and no cookie — same 401.
+#    Closes the "spoof Accept: text/html on a POST" bot pattern.
+curl -sD - -H "Accept: text/html" -X POST "$DIST/forms/anything" | head
 ```
 
-`X-Prosopo-Request-Id` is echoed on every response and written to Protect's verdict audit log — grep from a support ticket straight to the verdict. CloudFront's own `x-amz-cf-id` is the default request ID, so the same value shows up in CloudFront access logs and Protect's audit log.
+**If command 1 returns anything but 200:** you may be hitting your own origin's bot protection, not Prosopo's. AWS WAF, CloudFront's own managed rules, and similar tools reliably block curl regardless of what headers you set. Distinguish:
+
+- **Response has `x-prosopo-*` headers** → the 4xx is from Prosopo. Check `x-prosopo-status` and `x-prosopo-decision` — see [Troubleshooting](/protect-edge/troubleshooting).
+- **Response has `server: awselb` / no `x-prosopo-*` headers** → the 4xx is from your origin's own bot protection. Verify with a real browser instead.
+
+`X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log. CloudFront's own `x-amz-cf-id` is the default request ID, so the same value shows up in CloudFront access logs and Protect's audit log.
 
 ## Configuring proxy, VPN and datacenter blocking
 
@@ -141,12 +182,8 @@ Either source firing blocks the request at the edge. When both match, the more r
 
 ## Rotating credentials
 
-Each bundle is scoped to a specific site's authentication token. Rotating the token means requesting a fresh bundle from Prosopo and redeploying it via the [Deploy](#deploy) flow. The old bundle keeps working until you swap the ARN on your CloudFront behaviour.
+Each bundle is scoped to a specific site's authentication token. Rotating the token means requesting a fresh bundle from Prosopo and redeploying it via the [Deploy](#step-2-deploy-the-lambda) flow. The old bundle keeps working until you swap the ARN on your CloudFront behaviour.
 
 ## Troubleshooting
 
-- **CloudFront returns 502** — the function threw an unhandled exception. Check CloudWatch Logs in the region that served the request (Lambda@Edge writes logs region-locally).
-- **Requests return 401 with an internal-error body** — the bundle's authentication token is stale or invalid. Request a fresh bundle from Prosopo and redeploy.
-- **CloudFront won't accept the ARN** — Lambda@Edge requires a *published version* ARN (ending in `:1`, `:2`, …). `$LATEST` isn't accepted.
-- **Verdict lookups time out in logs** — Protect is unreachable or slow. The function fails open so requests still reach your origin, but investigate.
-- **`Unknown site` in logs** — your site isn't registered with Protect. Check your dashboard or contact your account manager.
+Common failure modes with their causes are on the dedicated [Troubleshooting page](/protect-edge/troubleshooting).

--- a/src/content/docs/en/protect-edge/lambda-edge.mdx
+++ b/src/content/docs/en/protect-edge/lambda-edge.mdx
@@ -8,14 +8,14 @@ The Prosopo Protect Lambda@Edge bundle runs on Amazon CloudFront's viewer-reques
 
 ## Two-part install: read this first
 
-A production Prosopo Protect integration is two independent pieces working together. Deploying only one leaves your site unprotected. Both are covered by this guide.
+A production Prosopo Protect integration is two independent pieces working together. Deploying only one leaves your site unprotected:
 
-1. **The Lambda@Edge bundle (server-side).** Runs on every CloudFront viewer request, executes the verdict, and blocks bad traffic before it reaches your origin. This is `lambda-edge.js`, deployed as a Lambda function and attached to a CloudFront behaviour.
-2. **The Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the edge returns a challenge. This is a single `<script>` tag in your HTML.
+- **Part 1: the Lambda@Edge bundle (server-side).** Runs on every CloudFront viewer request, executes the verdict, and blocks bad traffic before it reaches your origin. This is `lambda-edge.js`, deployed as a Lambda function and attached to a CloudFront behaviour.
+- **Part 2: the Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the edge returns a challenge. This is a single `<script>` tag in your HTML.
 
-Without the Lambda, no request is scored. Without the JS bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the Lambda path only, so a green Lambda with no JS bundle deployed looks like it's working while every real user still fails on their first XHR.
+Without the Lambda, no request is scored. Without the JS bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands under Part 1 test the Lambda path only, so a green Lambda with no JS bundle deployed looks like it's working while every real user still fails on their first XHR.
 
-Deploy them in either order, but ship both before rollout.
+Deploy the two parts in either order, but ship both before rollout. The sections below are organised under the same two headings.
 
 ## What you get
 
@@ -30,7 +30,9 @@ Deploy them in either order, but ship both before rollout.
   - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding. See [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist), which applies here too.
   - Issued you a bundle scoped to your site.
 
-## DNS: `protect.<your-domain>` as DNS-only
+## Part 1: the Lambda@Edge bundle (server-side)
+
+### 1a. DNS: `protect.<your-domain>` as DNS-only
 
 The bundle talks to Protect at a hostname you own, typically `protect.<your-domain>`. Create a CNAME record on your DNS pointing that hostname at Prosopo:
 
@@ -40,7 +42,7 @@ protect.<your-domain>   CNAME   protect.prosopo.io
 
 **Do not put this record behind a proxy layer (CloudFront, Cloudflare, or similar).** Prosopo's risk engine derives most of its bot-signal value from the raw TLS handshake (the JA4, JA4H, JA4L, and JA4T fingerprints). If a proxy terminates the browser's TLS at its edge and re-opens a fresh connection to Prosopo, the JA4 signals collapse to a single value per proxy stack and risk scoring degrades to noise. This subdomain must be DNS-only.
 
-### Coordinate cert issuance with your account manager
+### 1b. Coordinate cert issuance with your account manager
 
 Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain via Let's Encrypt on our infrastructure. This is a two-step handoff:
 
@@ -58,25 +60,7 @@ Once the cert is in place it auto-renews on our end every 60 days.
 
 The bundle you receive from Prosopo is built against your CNAMEd hostname, so you don't need to configure the URL yourself. If you rotate the CNAMEd hostname, request a fresh bundle.
 
-## Step 1: Add the Protect JS bundle to every HTML page
-
-**This step is mandatory.** Without the bundle no session cookie is ever set, and the Lambda returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity.
-
-Add this snippet to every HTML page your site serves. A shared header or footer template is the usual spot:
-
-```html
-<script>
-  window.prosopo_config = {
-    site_key: "<your-site-key>",
-    protect_url: "https://protect.<your-domain>"
-  };
-</script>
-<script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
-```
-
-Both tags are required. See the [Cloudflare Worker guide](/protect-edge/cloudflare-worker#step-1-add-the-protect-js-bundle-to-every-html-page) for a full explanation of what each tag does and how to gate fast form submissions with `data-prosopo-gate`.
-
-## Step 2: Deploy the Lambda
+### 1c. Deploy the Lambda
 
 Upload the bundle to Lambda, publish a version, and attach the versioned ARN to the CloudFront behaviour you want to protect.
 
@@ -116,7 +100,7 @@ CloudFront propagates to every edge location in 2 to 5 minutes. Repeat this atta
 
 Your account manager will let you know when a new bundle is available. Run `update-function-code` plus `publish-version` and point the behaviour at the new versioned ARN. CloudFront won't pick up `$LATEST`.
 
-### Execution role
+#### Execution role
 
 The function's role needs both `lambda.amazonaws.com` and `edgelambda.amazonaws.com` as trusted principals, plus the `AWSLambdaBasicExecutionRole` managed policy for CloudWatch Logs:
 
@@ -135,7 +119,7 @@ The function's role needs both `lambda.amazonaws.com` and `edgelambda.amazonaws.
 }
 ```
 
-## Verify
+### 1d. Verify the Lambda
 
 Once the trigger is attached and CloudFront has propagated, test through the distribution's domain.
 
@@ -163,6 +147,67 @@ curl -sD - -H "Accept: text/html" -X POST "$DIST/forms/anything" | head
 
 `X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log. CloudFront's own `x-amz-cf-id` is the default request ID, so the same value shows up in CloudFront access logs and Protect's audit log.
 
+Lambda verified? Move to Part 2.
+
+## Part 2: the Protect JS bundle (client-side)
+
+**This part is mandatory.** Without the bundle no session cookie is ever set, and the Lambda returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity. The Lambda verify commands under Part 1 still pass without the bundle; real user traffic doesn't.
+
+### 2a. Add the script tag to every HTML page
+
+Add this snippet to every HTML page your site serves. A shared header or footer template is the usual spot:
+
+```html
+<script>
+  window.prosopo_config = {
+    site_key: "<your-site-key>",
+    protect_url: "https://protect.<your-domain>"
+  };
+</script>
+<script src="https://js.protect.prosopo.io/protect.bundle.js" async></script>
+```
+
+Both tags are required. The first sets `window.prosopo_config` before the second loads; the bundle reads that config to know which Protect API to talk to. Skipping the first tag causes the bundle to fall back to the CDN's own origin (`js.protect.prosopo.io`) as its API URL, which returns 405 on the CORS preflight for `/api/protect/init` and hangs the bundle's patched `fetch`.
+
+On first page load the bundle:
+
+1. Calls `POST https://protect.<your-domain>/api/protect/init`.
+2. Receives a `prosopo_session` cookie scoped to `.<your-domain>`.
+3. Loads a per-session telemetry runtime script that collects the bot-signal data used for risk scoring.
+
+Every subsequent request from that browser carries the cookie, and the Lambda looks up a real verdict on `/api/*` or `/forms/*` calls.
+
+### 2b. Gate fast form submissions and link clicks (optional)
+
+Users can click **Submit** before the bundle finishes creating the session. The browser fires a full-page POST with no cookie and gets a 401. The security is correct but the UX is bad.
+
+Opt any form or link into automatic held-until-session-ready behaviour by adding the `data-prosopo-gate` attribute:
+
+```html
+<form action="/forms/search.php" method="post" data-prosopo-gate>
+  <!-- ... -->
+</form>
+
+<nav data-prosopo-gate>
+  <a href="/section-a/">Section A</a>
+  <a href="/section-b/">Section B</a>
+</nav>
+```
+
+The bundle intercepts marked forms and same-origin links in the capture phase, holds up to 8 seconds waiting for the session, then releases with the cookie in place. The submit button flips `disabled` and `aria-busy` while held so the user gets visual feedback. Ctrl/Cmd-click, middle-click, `target="_blank"`, `download` attributes, hash-only links, and cross-origin links pass through untouched.
+
+Attributes on an ancestor cover every descendant form or link, so `<nav data-prosopo-gate>` gates every link inside.
+
+### 2c. Verify the bundle
+
+Open your site in a real browser with DevTools on the Network tab. On first page load you should see:
+
+- A `POST` to `https://protect.<your-domain>/api/protect/init` returning `200` and a `Set-Cookie: prosopo_session=…` header.
+- A subsequent `GET https://protect.<your-domain>/api/protect/t/<jti>` fetching the per-session telemetry runtime.
+- The `prosopo_session` cookie set with `Domain=.<your-domain>` for later requests.
+
+If the init call goes to `https://js.protect.prosopo.io/api/protect/init` and returns 405, the `window.prosopo_config` block is missing from the snippet. See [Troubleshooting](/protect-edge/troubleshooting#http-401-no-session-on-every-user-request).
+
 ## Configuring proxy, VPN and datacenter blocking
 
 Blocking policy lives on your [Prosopo dashboard](https://portal.prosopo.io/), not in the bundle. Two independent rule sources feed the no-cookie edge path:
@@ -181,7 +226,7 @@ Either source firing blocks the request at the edge. When both match, the more r
 
 ## Rotating credentials
 
-Each bundle is scoped to a specific site's authentication token. Rotating the token means requesting a fresh bundle from Prosopo and redeploying it via the [Deploy](#step-2-deploy-the-lambda) flow. The old bundle keeps working until you swap the ARN on your CloudFront behaviour.
+Each bundle is scoped to a specific site's authentication token. Rotating the token means requesting a fresh bundle from Prosopo and redeploying it via the [Deploy the Lambda](#1c-deploy-the-lambda) flow. The old bundle keeps working until you swap the ARN on your CloudFront behaviour.
 
 ## Troubleshooting
 

--- a/src/content/docs/en/protect-edge/lambda-edge.mdx
+++ b/src/content/docs/en/protect-edge/lambda-edge.mdx
@@ -6,21 +6,20 @@ i18nReady: true
 
 The Prosopo Protect Lambda@Edge bundle runs on Amazon CloudFront's viewer-request trigger. It executes Protect's decision on every request and either forwards to your origin (`allow`), blocks it with a branded interstitial (`block`), or serves a captcha challenge (`challenge`).
 
-## Two-part install — read this first
+## Two-part install: read this first
 
-A production Prosopo Protect integration is **two independent pieces working together**. Deploying only one leaves your site unprotected. Both are covered by this guide.
+A production Prosopo Protect integration is two independent pieces working together. Deploying only one leaves your site unprotected. Both are covered by this guide.
 
-1. **The Lambda@Edge bundle (server-side).** Runs on every CloudFront viewer request. Executes the verdict, blocks bad traffic before it reaches your origin. This is `lambda-edge.js`, deployed as a Lambda function and attached to a CloudFront behaviour.
-
+1. **The Lambda@Edge bundle (server-side).** Runs on every CloudFront viewer request, executes the verdict, and blocks bad traffic before it reaches your origin. This is `lambda-edge.js`, deployed as a Lambda function and attached to a CloudFront behaviour.
 2. **The Protect JS bundle (client-side).** Loaded on every HTML page users visit. Creates the session cookie, collects the bot-signal telemetry the risk engine scores, and shows the captcha overlay when the edge returns a challenge. This is a single `<script>` tag in your HTML.
 
-Without the Lambda, no request is scored. Without the JS bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the Lambda path only — a green Lambda with no JS bundle deployed **looks working** but every real user still fails on their first XHR.
+Without the Lambda, no request is scored. Without the JS bundle, no user ever gets a session cookie, so every `/api/*` and `/forms/*` request returns 401 `no-session` forever. The verify commands at the bottom of this page test the Lambda path only, so a green Lambda with no JS bundle deployed looks like it's working while every real user still fails on their first XHR.
 
 Deploy them in either order, but ship both before rollout.
 
 ## What you get
 
-- `lambda-edge.js` — the bundle, delivered per site and per environment. Self-contained, ~100 KB. Same file for every customer; per-site config is baked in at build time.
+- `lambda-edge.js`: the bundle, delivered per site and per environment. Self-contained, ~100 KB. Same file for every customer; per-site config is baked in at build time.
 
 ## Prerequisites
 
@@ -28,18 +27,18 @@ Deploy them in either order, but ship both before rollout.
 - A CloudFront distribution serving your origin.
 - The [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) or the AWS Console.
 - Your Prosopo account manager has:
-  - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding — see [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist) (same list applies here).
+  - Registered your site key on the Protect dashboard with your intended `defaultPathType`, endpoint rules, IP-category rules, and interstitial branding. See [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist), which applies here too.
   - Issued you a bundle scoped to your site.
 
-## DNS: `protect.<your-domain>` as **DNS-only**
+## DNS: `protect.<your-domain>` as DNS-only
 
-The bundle talks to Protect at a hostname you own — typically `protect.<your-domain>`. Create a CNAME record on your DNS pointing that hostname at Prosopo:
+The bundle talks to Protect at a hostname you own, typically `protect.<your-domain>`. Create a CNAME record on your DNS pointing that hostname at Prosopo:
 
 ```
 protect.<your-domain>   CNAME   protect.prosopo.io
 ```
 
-**Do not put this record behind a proxy layer (CloudFront, Cloudflare, or similar).** Prosopo's risk engine derives most of its bot-signal value from the raw TLS handshake (JA4/JA4H/JA4L/JA4T fingerprints). If a proxy terminates the browser's TLS at its edge and re-opens a fresh connection to Prosopo, the JA4 signals collapse to a single value per proxy stack and risk scoring degrades to noise. This subdomain must be DNS-only.
+**Do not put this record behind a proxy layer (CloudFront, Cloudflare, or similar).** Prosopo's risk engine derives most of its bot-signal value from the raw TLS handshake (the JA4, JA4H, JA4L, and JA4T fingerprints). If a proxy terminates the browser's TLS at its edge and re-opens a fresh connection to Prosopo, the JA4 signals collapse to a single value per proxy stack and risk scoring degrades to noise. This subdomain must be DNS-only.
 
 ### Coordinate cert issuance with your account manager
 
@@ -53,17 +52,17 @@ Prosopo issues the TLS certificate for your `protect.<your-domain>` subdomain vi
    # and an A record resolving directly to our edge.
    ```
 
-2. **Us**: email your account manager once DNS is propagated. We issue the certificate on our end (~30 seconds), then confirm back. Attempting to deploy the Lambda before we've issued the cert results in TLS handshake failures on every access-check call, and the Lambda fails open — no request is actually scored.
+2. **Us**: email your account manager once DNS is propagated. We issue the certificate on our end (~30 seconds), then confirm back. Attempting to deploy the Lambda before we've issued the cert results in TLS handshake failures on every access-check call, and the Lambda fails open. No request is actually scored.
 
 Once the cert is in place it auto-renews on our end every 60 days.
 
-The bundle you receive from Prosopo is built against your CNAMEd hostname — you don't need to configure the URL yourself. If you rotate the CNAMEd hostname, request a fresh bundle.
+The bundle you receive from Prosopo is built against your CNAMEd hostname, so you don't need to configure the URL yourself. If you rotate the CNAMEd hostname, request a fresh bundle.
 
 ## Step 1: Add the Protect JS bundle to every HTML page
 
 **This step is mandatory.** Without the bundle no session cookie is ever set, and the Lambda returns 401 `no-session` on every `/api/*` or `/forms/*` call in perpetuity.
 
-Add this snippet to every HTML page your site serves — a shared header or footer template is the usual spot:
+Add this snippet to every HTML page your site serves. A shared header or footer template is the usual spot:
 
 ```html
 <script>
@@ -101,7 +100,7 @@ aws lambda update-function-code \
   --function-name prosopo-protect-viewer-request \
   --zip-file fileb://lambda-edge.zip
 
-# Publish a version — Lambda@Edge only accepts versioned ARNs
+# Publish a version. Lambda@Edge only accepts versioned ARNs.
 aws lambda publish-version \
   --region us-east-1 \
   --function-name prosopo-protect-viewer-request
@@ -113,9 +112,9 @@ The `publish-version` response includes a `FunctionArn` ending in `:<version-num
 - **Function type**: Lambda@Edge
 - **Function ARN**: the versioned ARN from `publish-version`.
 
-CloudFront propagates to every edge location in 2–5 minutes. Repeat this attach step for each behaviour that should be protected.
+CloudFront propagates to every edge location in 2 to 5 minutes. Repeat this attach step for each behaviour that should be protected.
 
-Your account manager will let you know when a new bundle is available. Run `update-function-code` + `publish-version` and point the behaviour at the new versioned ARN — CloudFront won't pick up `$LATEST`.
+Your account manager will let you know when a new bundle is available. Run `update-function-code` plus `publish-version` and point the behaviour at the new versioned ARN. CloudFront won't pick up `$LATEST`.
 
 ### Execution role
 
@@ -143,24 +142,24 @@ Once the trigger is attached and CloudFront has propagated, test through the dis
 ```bash
 DIST=https://your-distribution.cloudfront.net
 
-# 1. HTML — Protect should return "allow" (bootstrap-passthrough) and
+# 1. HTML: Protect should return "allow" (bootstrap-passthrough) and
 #    CloudFront forwards to your origin. Expected: 200, with
 #    x-prosopo-request-id in the response headers.
 curl -sD - -H "Accept: text/html" -H "User-Agent: Mozilla/5.0" "$DIST/" | head
 
-# 2. JSON, no cookie — Protect returns 401. Expected: 401,
+# 2. JSON, no cookie: Protect returns 401. Expected: 401,
 #    x-prosopo-status: no-session, x-prosopo-request-id.
 curl -sD - -H "Accept: application/json" "$DIST/api/anything" | head
 
-# 3. POST /forms/* with Accept: text/html and no cookie — same 401.
+# 3. POST /forms/* with Accept: text/html and no cookie: same 401.
 #    Closes the "spoof Accept: text/html on a POST" bot pattern.
 curl -sD - -H "Accept: text/html" -X POST "$DIST/forms/anything" | head
 ```
 
-**If command 1 returns anything but 200:** you may be hitting your own origin's bot protection, not Prosopo's. AWS WAF, CloudFront's own managed rules, and similar tools reliably block curl regardless of what headers you set. Distinguish:
+**If command 1 returns anything other than 200**, you may be hitting your own origin's bot protection, not Prosopo's. AWS WAF, CloudFront's own managed rules, and similar tools reliably block curl regardless of what headers you set. Distinguish:
 
-- **Response has `x-prosopo-*` headers** → the 4xx is from Prosopo. Check `x-prosopo-status` and `x-prosopo-decision` — see [Troubleshooting](/protect-edge/troubleshooting).
-- **Response has `server: awselb` / no `x-prosopo-*` headers** → the 4xx is from your origin's own bot protection. Verify with a real browser instead.
+- If the response has `x-prosopo-*` headers, the 4xx is from Prosopo. Check `x-prosopo-status` and `x-prosopo-decision`. See [Troubleshooting](/protect-edge/troubleshooting).
+- If the response has `server: awselb` and no `x-prosopo-*` headers, the 4xx is from your origin's own bot protection. Verify with a real browser instead.
 
 `X-Prosopo-Request-Id` is echoed on every response Prosopo returns and written to Protect's verdict audit log. CloudFront's own `x-amz-cf-id` is the default request ID, so the same value shows up in CloudFront access logs and Protect's audit log.
 
@@ -168,10 +167,10 @@ curl -sD - -H "Accept: text/html" -X POST "$DIST/forms/anything" | head
 
 Blocking policy lives on your [Prosopo dashboard](https://portal.prosopo.io/), not in the bundle. Two independent rule sources feed the no-cookie edge path:
 
-- **Site settings** — recognised IP categories: `tor`, `datacenter`, `proxy`, `vpn`, `abuser`, `mobile`, `crawler`. Configure per-category verdicts (`allow` / `challenge` / `block`).
-- **Tiered access rules** — support the full rule set: IP CIDR, ASN, IP category, country, User-Agent substring, JA4 TLS fingerprint. Rules can be scoped to your site or applied globally by Prosopo.
+- **Site settings**: recognised IP categories are `tor`, `datacenter`, `proxy`, `vpn`, `abuser`, `mobile`, and `crawler`. Configure per-category verdicts (`allow`, `challenge`, or `block`).
+- **Tiered access rules**: support the full rule set of IP CIDR, ASN, IP category, country, User-Agent substring, and JA4 TLS fingerprint. Rules can be scoped to your site or applied globally by Prosopo.
 
-Either source firing blocks the request at the edge. When both match, the more restrictive verdict wins (`Block > Challenge > Allow`). Policy changes take effect on the next request — no redeploy needed.
+Either source firing blocks the request at the edge. When both match, the more restrictive verdict wins (`Block > Challenge > Allow`). Policy changes take effect on the next request, no redeploy needed.
 
 ## Constraints
 

--- a/src/content/docs/en/protect-edge/lambda-edge.mdx
+++ b/src/content/docs/en/protect-edge/lambda-edge.mdx
@@ -19,7 +19,11 @@ Deploy the two parts in either order, but ship both before rollout. The sections
 
 ## What you get
 
-- `lambda-edge.js`: the bundle, delivered per site and per environment. Self-contained, ~100 KB. Same file for every customer; per-site config is baked in at build time.
+Part 1 (server-side) is delivered as a file:
+
+- `lambda-edge.js`: the Lambda code, delivered per site and per environment. Self-contained, ~100 KB. Same file for every customer; per-site config is baked in at build time.
+
+Part 2 (client-side) is hosted by us. You add one `<script>` tag pointing at `https://js.protect.prosopo.io/protect.bundle.js`. Nothing to download or bundle yourself. We publish new versions to that URL; your pages pick them up on their next reload without a redeploy from you.
 
 ## Prerequisites
 

--- a/src/content/docs/en/protect-edge/troubleshooting.mdx
+++ b/src/content/docs/en/protect-edge/troubleshooting.mdx
@@ -8,53 +8,53 @@ Common failure modes when deploying Prosopo Protect at the edge, with the actual
 
 ## Whose 4xx is this?
 
-`curl` returning a `4xx` from a URL that runs through both Prosopo and your own CDN's bot management isn't always Prosopo. Every response Prosopo emits carries `X-Prosopo-*` headers — every response from Cloudflare Bot Management, AWS WAF, and similar layers doesn't. That's the tell.
+A `curl` that returns a `4xx` from a URL running through both Prosopo and your own CDN's bot management isn't always Prosopo. Every response Prosopo emits carries `X-Prosopo-*` headers. Every response from Cloudflare Bot Management, AWS WAF, and similar layers doesn't. That's the tell.
 
-**Check the response headers first:**
+Check the response headers first:
 
 ```bash
 curl -sI https://<your-domain>/some/path
 ```
 
-| Response includes                     | Source                            | What to do                                                                                             |
-| ------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `x-prosopo-status: <status>`          | Prosopo                           | Look up `<status>` below.                                                                              |
-| `x-prosopo-decision: block`           | Prosopo                           | The verdict was `block`. See [Blocked by Prosopo](#blocked-by-prosopo).                                |
-| `x-prosopo-decision: challenge`       | Prosopo                           | The verdict was `challenge`. Real browsers see the captcha; `curl` cannot solve it.                    |
-| `server: cloudflare` and **no** `x-prosopo-*` | Cloudflare Bot Management         | Your zone's own bot rules. Check your Cloudflare dashboard → Security → Bots.                        |
-| `server: awselb` / `Server: CloudFront` and no `x-prosopo-*` | AWS WAF / CloudFront managed rules | Your distribution's own bot rules. Check AWS WAF console.                                             |
-| `server: nginx` / `Apache` / origin-specific | Your origin server itself         | Application-level auth, IP allowlist, or origin bot protection. Not Prosopo.                          |
+| Response includes | Source | What to do |
+|---|---|---|
+| `x-prosopo-status: <status>` | Prosopo | Look up `<status>` below. |
+| `x-prosopo-decision: block` | Prosopo | The verdict was `block`. See [Blocked by Prosopo](#blocked-by-prosopo). |
+| `x-prosopo-decision: challenge` | Prosopo | The verdict was `challenge`. Real browsers see the captcha; `curl` cannot solve it. |
+| `server: cloudflare` and **no** `x-prosopo-*` | Cloudflare Bot Management | Your zone's own bot rules. Check your Cloudflare dashboard, Security, Bots. |
+| `server: awselb` / `Server: CloudFront` and no `x-prosopo-*` | AWS WAF / CloudFront managed rules | Your distribution's own bot rules. Check AWS WAF console. |
+| `server: nginx` / `Apache` / origin-specific | Your origin server itself | Application-level auth, IP allowlist, or origin bot protection. Not Prosopo. |
 
-When in doubt, hit Prosopo directly (bypass the edge worker) with `curl -H "Host: your-domain.com" https://protect.your-domain.com/api/protect/anything` — an `x-prosopo-*` header appears on that response, confirming Prosopo is reachable.
+When in doubt, hit Prosopo directly (bypass the edge worker) with `curl -H "Host: your-domain.com" https://protect.your-domain.com/api/protect/anything`. An `x-prosopo-*` header appears on that response, confirming Prosopo is reachable.
 
 ## Prosopo status codes
 
 Every non-`allow` response from Prosopo sets `X-Prosopo-Status`:
 
-| Status                | Meaning                                                                                                                                                                                                                                     |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `no-session`          | Request has no `prosopo_session` cookie and hit a path declared as `pathType: json`. Not necessarily an error — this is the expected response for a first-time API call before the client bundle has established a session.                |
-| `invalid-session`     | The `prosopo_session` cookie value can't be parsed (truncated, tampered with, or a stale format). Client should clear the cookie and let the bundle re-initialise.                                                                        |
-| `session-not-found`   | The JTI in the cookie doesn't match any live session record. Usually a session that expired or was evicted from Redis. Client should re-initialise.                                                                                        |
+| Status | Meaning |
+|---|---|
+| `no-session` | Request has no `prosopo_session` cookie and hit a path declared as `pathType: json`. Not necessarily an error. This is the expected response for a first-time API call before the client bundle has established a session. |
+| `invalid-session` | The `prosopo_session` cookie value can't be parsed (truncated, tampered with, or a stale format). Client should clear the cookie and let the bundle re-initialise. |
+| `session-not-found` | The JTI in the cookie doesn't match any live session record. Usually a session that expired or was evicted from Redis. Client should re-initialise. |
 
 ## Blocked by Prosopo
 
-When Prosopo returns `x-prosopo-decision: block`, the response body (HTML for browsers, JSON for API calls) explains why. The `X-Prosopo-Request-Id` header — echoed on every response and also rendered as `Reference: <id>` on the blocked interstitial — is the audit-log key. Quote it in support conversations and we can grep straight to the exact verdict that fired.
+When Prosopo returns `x-prosopo-decision: block`, the response body (HTML for browsers, JSON for API calls) explains why. The `X-Prosopo-Request-Id` header, echoed on every response and also rendered as `Reference: <id>` on the blocked interstitial, is the audit-log key. Quote it in support conversations and we can grep straight to the exact verdict that fired.
 
 Common block sources:
 
-- **IP category** — the client IP was flagged as `tor`, `abuser`, `proxy`, etc., and your Portal has that category set to `block`. Change on your [Prosopo dashboard](https://portal.prosopo.io/) under Site settings → IP category rules.
-- **Access rule** — an operator-added rule matched the request (IP CIDR, ASN, User-Agent, JA4, country). Change on your dashboard under Access rules.
-- **Risk score above threshold** — the verdict from the risk engine crossed the configured block threshold (default `0.85`). Investigate the individual rules that fired via the verdict audit log — your account manager can pull the row from the `X-Prosopo-Request-Id`.
+- **IP category**: the client IP was flagged as `tor`, `abuser`, `proxy`, etc., and your Portal has that category set to `block`. Change on your [Prosopo dashboard](https://portal.prosopo.io/) under Site settings, IP category rules.
+- **Access rule**: an operator-added rule matched the request (IP CIDR, ASN, User-Agent, JA4, country). Change on your dashboard under Access rules.
+- **Risk score above threshold**: the verdict from the risk engine crossed the configured block threshold (default `0.85`). Investigate the individual rules that fired via the verdict audit log. Your account manager can pull the row from the `X-Prosopo-Request-Id`.
 
 ## Known-benign browser console warnings
 
 Warnings that appear in the browser DevTools console during normal Protect operation. None of these break functionality; ignore them.
 
-| Warning                                                                                            | When you'll see it                                                                                                            | Fixed in                                                                                          |
-| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| `Refused to get unsafe header "x-prosopo-request-id"`                                             | Bundle reading the request-id header on cross-origin responses that don't expose it via `Access-Control-Expose-Headers`.       | Bundle fixed 2026-08-19. Redeploy from the CDN if you're on an older cached copy.                 |
-| `[Violation] Permissions policy violation: unload is not allowed in this document.`                | Telemetry runtime registered an `unload` handler (deprecated in Chrome via Permissions-Policy).                                | Telemetry runtime fixed 2026-08-19. Users on the current bundle no longer see this.                 |
+| Warning | When you'll see it | Fixed in |
+|---|---|---|
+| `Refused to get unsafe header "x-prosopo-request-id"` | Bundle reading the request-id header on cross-origin responses that don't expose it via `Access-Control-Expose-Headers`. | Bundle fixed 2026-08-19. Redeploy from the CDN if you're on an older cached copy. |
+| `[Violation] Permissions policy violation: unload is not allowed in this document.` | Telemetry runtime registered an `unload` handler (deprecated in Chrome via Permissions-Policy). | Telemetry runtime fixed 2026-08-19. Users on the current bundle no longer see this. |
 
 If you're seeing either warning on a bundle that should be current, hard-refresh (Ctrl-Shift-R) to bypass the browser cache. The bundle sets a short cache lifetime so refreshes propagate quickly.
 
@@ -62,7 +62,7 @@ If you're seeing either warning on a bundle that should be current, hard-refresh
 
 **Symptom:** `wrangler tail` shows `access-check returned 526` on every request. Worker fails open (requests reach your origin but Prosopo scored none of them).
 
-**Cause:** Cloudflare can't complete the TLS handshake to `protect.<your-domain>` because the certificate on our end hasn't been issued yet, OR the CNAME record is orange-cloud (proxied) so Cloudflare's edge fingerprints your worker as talking to itself.
+**Cause:** Cloudflare can't complete the TLS handshake to `protect.<your-domain>` because the certificate on our end hasn't been issued yet, or the CNAME record is orange-cloud (proxied) so Cloudflare's edge fingerprints your worker as talking to itself.
 
 **Fix:**
 
@@ -78,17 +78,17 @@ If you're seeing either warning on a bundle that should be current, hard-refresh
 
 ## `HTTP 401 no-session` on every user request
 
-**Symptom:** Real users' API calls return `401 no-session`. Only affects paths declared as `pathType: json` (typically `/api/*`, `/forms/*`). The verify commands from the guides still show the expected 401 — you already know that's the correct response for a cookie-less curl.
+**Symptom:** Real users' API calls return `401 no-session`. Only affects paths declared as `pathType: json` (typically `/api/*`, `/forms/*`). The verify commands from the guides still show the expected 401. You already know that's the correct response for a cookie-less curl.
 
 **Cause:** No user is establishing a session. Usually because the Protect JS bundle isn't loaded on your HTML pages, or the `window.prosopo_config` block is missing from the snippet.
 
 **Fix:**
 
 1. Load a page from your site in a real browser with DevTools open on the Network tab.
-2. Filter for `protect.bundle.js`. If it's not there, the `<script>` tag isn't reaching your HTML — check your header/footer template.
+2. Filter for `protect.bundle.js`. If it's not there, the `<script>` tag isn't reaching your HTML. Check your header or footer template.
 3. Filter for `/api/protect/init`. It should be a `POST` to `https://protect.<your-domain>` returning 200 with `Set-Cookie: prosopo_session=…`.
 
-   - If it's going to `https://js.protect.prosopo.io/api/protect/init` instead and getting a 405, your snippet is missing the `window.prosopo_config` block. Add it above the `<script src=…>` line — see [the CF Worker install step](/protect-edge/cloudflare-worker#step-1-add-the-protect-js-bundle-to-every-html-page).
+   - If it's going to `https://js.protect.prosopo.io/api/protect/init` instead and getting a 405, your snippet is missing the `window.prosopo_config` block. Add it above the `<script src=…>` line. See [the CF Worker install step](/protect-edge/cloudflare-worker#step-1-add-the-protect-js-bundle-to-every-html-page).
    - If it's going to the right hostname but returning `4xx`, check the Portal settings and DNS.
 4. Filter for cookies. The `prosopo_session` cookie should be set with `Domain=.<your-domain>` after the init call.
 
@@ -96,15 +96,15 @@ If you're seeing either warning on a bundle that should be current, hard-refresh
 
 **Symptom:** Immediately after Prosopo publishes a new telemetry runtime bundle, some legitimate telemetry POSTs from your users fail with 400 `Failed to decrypt telemetry payload`. Volume declines over minutes to hours.
 
-**Cause:** Browsers that had cached an older telemetry bundle continue to encrypt telemetry with the old public key. Once the rotation happens on our side, only the new private key is retained, so old-key payloads fail decryption. The bundle catches the 400 silently — no user-visible impact.
+**Cause:** Browsers that had cached an older telemetry bundle continue to encrypt telemetry with the old public key. Once the rotation happens on our side, only the new private key is retained, so old-key payloads fail decryption. The bundle catches the 400 silently. No user-visible impact.
 
-**Fix:** No action. The transient decays as browser caches expire and users reload pages. Session initialisation, verdict lookups, and captcha flows are unaffected — they use the client bundle's public request path, not the telemetry channel.
+**Fix:** No action. The transient decays as browser caches expire and users reload pages. Session initialisation, verdict lookups, and captcha flows are unaffected. They use the client bundle's public request path, not the telemetry channel.
 
 ## Verify commands return `200` from the worker but nothing appears in the verdict audit log
 
 **Symptom:** `curl` against the worker returns `200` with `x-prosopo-*` headers, but the dashboard shows no verdict rows for your site.
 
-**Cause:** The worker's forward to your origin succeeded, but the `X-Prosopo-Decision` on the response was `allow` — those aren't logged in the same way as `block` / `challenge`. Successful passes are counted in the traffic summary, not the individual verdict log.
+**Cause:** The worker's forward to your origin succeeded, but the `X-Prosopo-Decision` on the response was `allow`. Those aren't logged in the same way as `block` or `challenge`. Successful passes are counted in the traffic summary, not the individual verdict log.
 
 Check the dashboard's traffic summary for your site to see request throughput broken down by verdict.
 
@@ -112,10 +112,10 @@ Check the dashboard's traffic summary for your site to see request throughput br
 
 **Symptom:** Behaviour changed without anyone deploying. Verify commands that previously worked now fail (or vice versa).
 
-**Cause:** Someone edited your Protect instance's settings on the dashboard, OR our sync process pushed a stale copy back over a manual Redis edit.
+**Cause:** Someone edited your Protect instance's settings on the dashboard, or our sync process pushed a stale copy back over a manual Redis edit.
 
-**Fix:** Cross-check the current Portal settings against the [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist). If a field doesn't match, the dashboard is the source of truth — update there.
+**Fix:** Cross-check the current Portal settings against the [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist). If a field doesn't match, the dashboard is the source of truth; update there.
 
 ## Getting help
 
-Grab the `X-Prosopo-Request-Id` from any failing request and share it with your account manager. It's the audit-log key — one string gets us straight to the exact verdict, all the input signals, the rules that fired, and the response we returned.
+Grab the `X-Prosopo-Request-Id` from any failing request and share it with your account manager. It's the audit-log key. One string gets us straight to the exact verdict, all the input signals, the rules that fired, and the response we returned.

--- a/src/content/docs/en/protect-edge/troubleshooting.mdx
+++ b/src/content/docs/en/protect-edge/troubleshooting.mdx
@@ -1,0 +1,121 @@
+---
+title: Troubleshooting
+description: Distinguish Prosopo Protect 4xx responses from other bot-protection layers, recognise known-harmless browser console warnings, and diagnose the most common misconfigurations in an edge deployment.
+i18nReady: true
+---
+
+Common failure modes when deploying Prosopo Protect at the edge, with the actual causes rather than the surface symptoms.
+
+## Whose 4xx is this?
+
+`curl` returning a `4xx` from a URL that runs through both Prosopo and your own CDN's bot management isn't always Prosopo. Every response Prosopo emits carries `X-Prosopo-*` headers — every response from Cloudflare Bot Management, AWS WAF, and similar layers doesn't. That's the tell.
+
+**Check the response headers first:**
+
+```bash
+curl -sI https://<your-domain>/some/path
+```
+
+| Response includes                     | Source                            | What to do                                                                                             |
+| ------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `x-prosopo-status: <status>`          | Prosopo                           | Look up `<status>` below.                                                                              |
+| `x-prosopo-decision: block`           | Prosopo                           | The verdict was `block`. See [Blocked by Prosopo](#blocked-by-prosopo).                                |
+| `x-prosopo-decision: challenge`       | Prosopo                           | The verdict was `challenge`. Real browsers see the captcha; `curl` cannot solve it.                    |
+| `server: cloudflare` and **no** `x-prosopo-*` | Cloudflare Bot Management         | Your zone's own bot rules. Check your Cloudflare dashboard → Security → Bots.                        |
+| `server: awselb` / `Server: CloudFront` and no `x-prosopo-*` | AWS WAF / CloudFront managed rules | Your distribution's own bot rules. Check AWS WAF console.                                             |
+| `server: nginx` / `Apache` / origin-specific | Your origin server itself         | Application-level auth, IP allowlist, or origin bot protection. Not Prosopo.                          |
+
+When in doubt, hit Prosopo directly (bypass the edge worker) with `curl -H "Host: your-domain.com" https://protect.your-domain.com/api/protect/anything` — an `x-prosopo-*` header appears on that response, confirming Prosopo is reachable.
+
+## Prosopo status codes
+
+Every non-`allow` response from Prosopo sets `X-Prosopo-Status`:
+
+| Status                | Meaning                                                                                                                                                                                                                                     |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `no-session`          | Request has no `prosopo_session` cookie and hit a path declared as `pathType: json`. Not necessarily an error — this is the expected response for a first-time API call before the client bundle has established a session.                |
+| `invalid-session`     | The `prosopo_session` cookie value can't be parsed (truncated, tampered with, or a stale format). Client should clear the cookie and let the bundle re-initialise.                                                                        |
+| `session-not-found`   | The JTI in the cookie doesn't match any live session record. Usually a session that expired or was evicted from Redis. Client should re-initialise.                                                                                        |
+
+## Blocked by Prosopo
+
+When Prosopo returns `x-prosopo-decision: block`, the response body (HTML for browsers, JSON for API calls) explains why. The `X-Prosopo-Request-Id` header — echoed on every response and also rendered as `Reference: <id>` on the blocked interstitial — is the audit-log key. Quote it in support conversations and we can grep straight to the exact verdict that fired.
+
+Common block sources:
+
+- **IP category** — the client IP was flagged as `tor`, `abuser`, `proxy`, etc., and your Portal has that category set to `block`. Change on your [Prosopo dashboard](https://portal.prosopo.io/) under Site settings → IP category rules.
+- **Access rule** — an operator-added rule matched the request (IP CIDR, ASN, User-Agent, JA4, country). Change on your dashboard under Access rules.
+- **Risk score above threshold** — the verdict from the risk engine crossed the configured block threshold (default `0.85`). Investigate the individual rules that fired via the verdict audit log — your account manager can pull the row from the `X-Prosopo-Request-Id`.
+
+## Known-benign browser console warnings
+
+Warnings that appear in the browser DevTools console during normal Protect operation. None of these break functionality; ignore them.
+
+| Warning                                                                                            | When you'll see it                                                                                                            | Fixed in                                                                                          |
+| -------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `Refused to get unsafe header "x-prosopo-request-id"`                                             | Bundle reading the request-id header on cross-origin responses that don't expose it via `Access-Control-Expose-Headers`.       | Bundle fixed 2026-08-19. Redeploy from the CDN if you're on an older cached copy.                 |
+| `[Violation] Permissions policy violation: unload is not allowed in this document.`                | Telemetry runtime registered an `unload` handler (deprecated in Chrome via Permissions-Policy).                                | Telemetry runtime fixed 2026-08-19. Users on the current bundle no longer see this.                 |
+
+If you're seeing either warning on a bundle that should be current, hard-refresh (Ctrl-Shift-R) to bypass the browser cache. The bundle sets a short cache lifetime so refreshes propagate quickly.
+
+## `HTTP 526` from the worker to Prosopo
+
+**Symptom:** `wrangler tail` shows `access-check returned 526` on every request. Worker fails open (requests reach your origin but Prosopo scored none of them).
+
+**Cause:** Cloudflare can't complete the TLS handshake to `protect.<your-domain>` because the certificate on our end hasn't been issued yet, OR the CNAME record is orange-cloud (proxied) so Cloudflare's edge fingerprints your worker as talking to itself.
+
+**Fix:**
+
+1. Confirm the CNAME record is DNS-only (grey cloud):
+
+   ```bash
+   dig protect.<your-domain>
+   # A record MUST NOT be a Cloudflare edge IP (104.x, 172.x range).
+   # It should resolve directly to Prosopo's edge via the CNAME chain.
+   ```
+
+2. Email your Prosopo account manager. We issue the Let's Encrypt certificate on our end (~30 seconds), confirm back, and the 526s stop on the next request.
+
+## `HTTP 401 no-session` on every user request
+
+**Symptom:** Real users' API calls return `401 no-session`. Only affects paths declared as `pathType: json` (typically `/api/*`, `/forms/*`). The verify commands from the guides still show the expected 401 — you already know that's the correct response for a cookie-less curl.
+
+**Cause:** No user is establishing a session. Usually because the Protect JS bundle isn't loaded on your HTML pages, or the `window.prosopo_config` block is missing from the snippet.
+
+**Fix:**
+
+1. Load a page from your site in a real browser with DevTools open on the Network tab.
+2. Filter for `protect.bundle.js`. If it's not there, the `<script>` tag isn't reaching your HTML — check your header/footer template.
+3. Filter for `/api/protect/init`. It should be a `POST` to `https://protect.<your-domain>` returning 200 with `Set-Cookie: prosopo_session=…`.
+
+   - If it's going to `https://js.protect.prosopo.io/api/protect/init` instead and getting a 405, your snippet is missing the `window.prosopo_config` block. Add it above the `<script src=…>` line — see [the CF Worker install step](/protect-edge/cloudflare-worker#step-1-add-the-protect-js-bundle-to-every-html-page).
+   - If it's going to the right hostname but returning `4xx`, check the Portal settings and DNS.
+4. Filter for cookies. The `prosopo_session` cookie should be set with `Domain=.<your-domain>` after the init call.
+
+## Bundle rotation errors after a telemetry redeploy
+
+**Symptom:** Immediately after Prosopo publishes a new telemetry runtime bundle, some legitimate telemetry POSTs from your users fail with 400 `Failed to decrypt telemetry payload`. Volume declines over minutes to hours.
+
+**Cause:** Browsers that had cached an older telemetry bundle continue to encrypt telemetry with the old public key. Once the rotation happens on our side, only the new private key is retained, so old-key payloads fail decryption. The bundle catches the 400 silently — no user-visible impact.
+
+**Fix:** No action. The transient decays as browser caches expire and users reload pages. Session initialisation, verdict lookups, and captcha flows are unaffected — they use the client bundle's public request path, not the telemetry channel.
+
+## Verify commands return `200` from the worker but nothing appears in the verdict audit log
+
+**Symptom:** `curl` against the worker returns `200` with `x-prosopo-*` headers, but the dashboard shows no verdict rows for your site.
+
+**Cause:** The worker's forward to your origin succeeded, but the `X-Prosopo-Decision` on the response was `allow` — those aren't logged in the same way as `block` / `challenge`. Successful passes are counted in the traffic summary, not the individual verdict log.
+
+Check the dashboard's traffic summary for your site to see request throughput broken down by verdict.
+
+## Configuration drift
+
+**Symptom:** Behaviour changed without anyone deploying. Verify commands that previously worked now fail (or vice versa).
+
+**Cause:** Someone edited your Protect instance's settings on the dashboard, OR our sync process pushed a stale copy back over a manual Redis edit.
+
+**Fix:** Cross-check the current Portal settings against the [Portal settings checklist](/protect-edge/cloudflare-worker#portal-settings-checklist). If a field doesn't match, the dashboard is the source of truth — update there.
+
+## Getting help
+
+Grab the `X-Prosopo-Request-Id` from any failing request and share it with your account manager. It's the audit-log key — one string gets us straight to the exact verdict, all the input signals, the rules that fired, and the response we returned.

--- a/src/i18n/en/nav.ts
+++ b/src/i18n/en/nav.ts
@@ -112,6 +112,11 @@ export default [
         slug: 'protect-edge/lambda-edge',
         key: 'protect-edge/lambda-edge',
     },
+    {
+        text: 'Troubleshooting',
+        slug: 'protect-edge/troubleshooting',
+        key: 'protect-edge/troubleshooting',
+    },
     {text: 'Framework integrations', header: true, type: 'learn', key: 'framework-integrations'},
     {
         text: 'Angular Integration',


### PR DESCRIPTION
## Summary

Full retrospective-driven rewrite of the Protect-Edge docs, derived from the trainoclock onboarding (Aug 2026) which cancelled after three consecutive \"looks broken\" moments — every one on us.

## Doc-side gaps this closes

Each failure mode from the trainoclock timeline has a specific new prevention:

| Trainoclock hit                                                                                           | Doc-side prevention                                                                                                              |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
| Days lost on HTTP 526 (cert never issued)                                                                 | Explicit cert-issuance handoff step; dig-check for Prosopo edge IP (not CF); \"do not deploy before we've issued the cert\".         |
| CNAME set as orange-cloud → JA4 fingerprints collapsed                                                     | Prominent \"DNS-only, not proxied\" section with the JA4/TLS-termination rationale explicit.                                        |
| Deployed the worker alone, no JS bundle → 401 forever                                                     | \"Two-part install\" banner at the top of every guide; the index page's opening also leads with it.                                 |
| One-tag bundle install snippet → CDN fallback → CORS 405 → session init hangs                              | New Step 1 with the two-tag snippet showing `window.prosopo_config = {…}` set before the bundle loads. Explanation of why.        |
| \"Refused to get unsafe header\" + \"unload not allowed\" browser console warnings scared the customer       | New Troubleshooting page with the known-benign warnings tabulated (fixed in #499 and #500), so future customers can pattern-match. |
| CF Bot Management on customer's own zone returned 403 → blamed us                                          | Verify commands now include the \"whose 4xx is this?\" flowchart via `x-prosopo-*` header presence.                                 |
| Portal settings had drifted from claimed defaults (`defaultPathType: json` on a server-rendered site)     | Portal settings checklist table the customer can visually diff on the dashboard before deploying.                                |
| ORIGIN_URL described in docs but code didn't implement forwarding                                          | ORIGIN_URL now correctly documented in wrangler.toml example (code fix landed 2026-08-05). Two-hostname pattern explained.       |

## Files

- `src/content/docs/en/protect-edge/cloudflare-worker.mdx` — full rewrite.
- `src/content/docs/en/protect-edge/lambda-edge.mdx` — parallel rewrite.
- `src/content/docs/en/protect-edge/index.mdx` — added Two-part install callout, referenced Troubleshooting.
- `src/content/docs/en/protect-edge/troubleshooting.mdx` — **new page**.
- `src/i18n/en/nav.ts` — added Troubleshooting entry under Prosopo Protect (Edge).

## Companion internal doc

`protect/ONBOARDING_CHECKLIST.md` (in the captcha-private repo, separate PR) — pre-handoff checklist for us: cert issued, portal settings verified, README shape-checked, CLIENT_JWT delivered securely, verify from an external machine before handoff.

## Test plan

- [ ] `npm run build` locally in `packages/docs` to confirm the new page renders and the nav shows Troubleshooting. (I haven't run this — recommend reviewer does before merge.)
- [ ] Cross-reference: every internal link in the new/rewritten pages should target a slug that exists in `nav.ts` (`/protect-edge/troubleshooting` and hash anchors within cloudflare-worker.mdx / lambda-edge.mdx).

Translations (fr, de, es, it, pt-br): only en/ updated in this pass; translations will need a matching sweep in a follow-up (existing pattern: create the file in each locale, mark `i18nReady: false` at first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)